### PR TITLE
feat(auth): Tenant entity e fluxo de registro de novo tenant

### DIFF
--- a/1 - Gateway/MundoDaLua.GraphQL/Extensions/MigrationExtensions.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/Extensions/MigrationExtensions.cs
@@ -24,31 +24,41 @@ public static class MigrationExtensions
 
         var tenantService = sp.GetRequiredService<ITenantService>();
 
-        // CRM seed first so the admin Person exists.
+        // CRM seed first so the admin Person and Company exist.
         await DataSeeder.SeedAsync(customersDb, tenantService);
 
-        // Fetch the admin PersonId in CRM to link it to admin User in Auth.
+        // Fetch the admin PersonId and CompanyId from CRM to link to Auth.
         tenantService.SetTenant(DataSeeder.SeedTenantId);
-        var adminPersonId = await GetAdminPersonIdAsync(customersDb);
+        var adminPersonId  = await GetAdminPersonIdAsync(customersDb);
+        var adminCompanyId = await GetSeedCompanyIdAsync(customersDb);
 
         // Sync system permissions before ensuring admin role permissions.
         await PermissionSeeder.SeedAsync(authDb);
 
-        // Seed auth data and guarantee admin role has all active permissions.
-        await AuthDataSeeder.SeedAsync(authDb, tenantService, adminPersonId);
+        // Seed Tenant + auth data and guarantee admin role has all active permissions.
+        await AuthDataSeeder.SeedAsync(authDb, tenantService, adminPersonId, adminCompanyId);
     }
 
     private static async Task<Guid?> GetAdminPersonIdAsync(CRMDbContext crmDb)
     {
         const string adminEmail = "admin@mundodalua.com";
 
-        var person = await crmDb.People
+        return await crmDb.People
             .IgnoreQueryFilters()
             .Where(p => p.Email == adminEmail)
             .Select(p => (Guid?)p.Id)
             .FirstOrDefaultAsync();
+    }
 
-        return person;
+    private static async Task<Guid?> GetSeedCompanyIdAsync(CRMDbContext crmDb)
+    {
+        const string seedCnpj = "12.345.678/0001-90"; // Mundo da Lua Educação Ltda
+
+        return await crmDb.Companies
+            .IgnoreQueryFilters()
+            .Where(c => c.RegistrationNumber == seedCnpj)
+            .Select(c => (Guid?)c.Id)
+            .FirstOrDefaultAsync();
     }
 
     private static async Task ResetMigrationsIfSchemaLostAsync(DbContext db, string schema, string table)

--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Tenants/Inputs/RegisterTenantInput.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Tenants/Inputs/RegisterTenantInput.cs
@@ -1,0 +1,22 @@
+namespace MyCRM.GraphQL.GraphQL.Tenants.Inputs;
+
+/// <summary>
+/// Dados mínimos para registrar um novo tenant.
+/// Cria em uma única operação: Empresa (CRM) + Pessoa admin (CRM) + Tenant + Usuário de acesso (Auth).
+/// </summary>
+public record RegisterTenantInput(
+    // ── Empresa ──────────────────────────────────────────────────────────────
+    string CompanyLegalName,
+    string? CompanyCnpj,
+    string? CompanyEmail,
+    string? CompanyPhone,
+
+    // ── Pessoa / administrador ────────────────────────────────────────────────
+    string AdminName,
+    string AdminEmail,
+    string? AdminCpf,
+    string? AdminPhone,
+
+    // ── Acesso ───────────────────────────────────────────────────────────────
+    string Password,
+    string PasswordConfirmation);

--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Tenants/TenantMutations.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Tenants/TenantMutations.cs
@@ -1,0 +1,41 @@
+using MediatR;
+using MyCRM.Auth.Application.Commands.Tenants.RegisterTenant;
+using MyCRM.GraphQL.GraphQL.Tenants.Inputs;
+
+namespace MyCRM.GraphQL.GraphQL.Tenants;
+
+[MutationType]
+public sealed class TenantMutations
+{
+    /// <summary>
+    /// Registra um novo tenant criando empresa, pessoa administradora e acesso em uma única operação.
+    /// Mutation pública — não requer autenticação.
+    /// </summary>
+    [AllowAnonymous]
+    public async Task<TenantPayload> RegisterTenantAsync(
+        RegisterTenantInput input,
+        [Service] ISender sender,
+        CancellationToken ct)
+    {
+        var result = await sender.Send(new RegisterTenantCommand(
+            input.CompanyLegalName,
+            input.CompanyCnpj,
+            input.CompanyEmail,
+            input.CompanyPhone,
+            input.AdminName,
+            input.AdminEmail,
+            input.AdminCpf,
+            input.AdminPhone,
+            input.Password,
+            input.PasswordConfirmation), ct);
+
+        return result.IsSuccess
+            ? new TenantPayload(result.Value!)
+            : throw new GraphQLException(
+                result.Errors.Select(e =>
+                    ErrorBuilder.New()
+                        .SetMessage(e)
+                        .SetExtension("code", result.ErrorCode)
+                        .Build()));
+    }
+}

--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Tenants/TenantPayload.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Tenants/TenantPayload.cs
@@ -1,0 +1,5 @@
+using MyCRM.Auth.Application.DTOs;
+
+namespace MyCRM.GraphQL.GraphQL.Tenants;
+
+public record TenantPayload(TenantDto Tenant);

--- a/1 - Gateway/MundoDaLua.GraphQL/Program.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/Program.cs
@@ -140,6 +140,7 @@ builder.Services
     .AddTypeExtension<MyCRM.GraphQL.GraphQL.StudentCourses.StudentCourseMutations>()
     .AddTypeExtension<MyCRM.GraphQL.GraphQL.Employees.EmployeeQueries>()
     .AddTypeExtension<MyCRM.GraphQL.GraphQL.Employees.EmployeeMutations>()
+    .AddTypeExtension<MyCRM.GraphQL.GraphQL.Tenants.TenantMutations>()
     .AddType<MyCRM.GraphQL.GraphQL.Customers.CustomerObjectType>()
     .AddAuthorization()
     .AddFiltering()

--- a/2 - CRM/CRM.Infrastructure/DependencyInjection.cs
+++ b/2 - CRM/CRM.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,8 @@
 using MyCRM.CRM.Domain.Repositories;
 using MyCRM.CRM.Infrastructure.Persistence;
 using MyCRM.CRM.Infrastructure.Repositories;
+using MyCRM.CRM.Infrastructure.Services;
+using MyCRM.Shared.Kernel.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,6 +24,7 @@ public static class DependencyInjection
         services.AddScoped<ICourseRepository, CourseRepository>();
         services.AddScoped<IStudentCourseRepository, StudentCourseRepository>();
         services.AddScoped<IEmployeeRepository, EmployeeRepository>();
+        services.AddScoped<ICrmTenantProvisioningService, CrmTenantProvisioningService>();
 
         return services;
     }

--- a/2 - CRM/CRM.Infrastructure/Services/CrmTenantProvisioningService.cs
+++ b/2 - CRM/CRM.Infrastructure/Services/CrmTenantProvisioningService.cs
@@ -1,0 +1,65 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Infrastructure.Persistence;
+using MyCRM.Shared.Kernel.MultiTenancy;
+using MyCRM.Shared.Kernel.Services;
+
+namespace MyCRM.CRM.Infrastructure.Services;
+
+/// <summary>
+/// Cria os registros CRM (Company + Person) durante o provisionamento de um novo tenant.
+///
+/// Chama tenantService.SetTenant() com o tenantId fornecido antes de salvar, garantindo
+/// que o CRMDbContext.SaveChangesAsync() injete o TenantId correto nas entidades.
+/// </summary>
+public sealed class CrmTenantProvisioningService : ICrmTenantProvisioningService
+{
+    private readonly CRMDbContext _db;
+    private readonly ITenantService _tenantService;
+
+    public CrmTenantProvisioningService(CRMDbContext db, ITenantService tenantService)
+    {
+        _db            = db;
+        _tenantService = tenantService;
+    }
+
+    public async Task<TenantCrmData> ProvisionAsync(
+        Guid tenantId,
+        string companyLegalName,
+        string? companyCnpj,
+        string? companyEmail,
+        string? companyPhone,
+        string personFullName,
+        string personEmail,
+        string? personDocumentNumber,
+        string? personPhone,
+        CancellationToken ct = default)
+    {
+        // Define o tenant antes de qualquer operação — necessário para que
+        // CRMDbContext.SaveChangesAsync() injete o TenantId correto.
+        _tenantService.SetTenant(tenantId);
+
+        // Cria a Company
+        var company = Company.Create(
+            tenantId:          tenantId,
+            legalName:         companyLegalName,
+            registrationNumber: companyCnpj,
+            email:             companyEmail,
+            primaryPhone:      companyPhone);
+
+        await _db.Companies.AddAsync(company, ct);
+
+        // Cria a Person (administrador)
+        var person = Person.Create(
+            tenantId:       tenantId,
+            fullName:       personFullName,
+            email:          personEmail,
+            documentNumber: personDocumentNumber,
+            primaryPhone:   personPhone);
+
+        await _db.People.AddAsync(person, ct);
+
+        await _db.SaveChangesAsync(ct);
+
+        return new TenantCrmData(company.Id, person.Id);
+    }
+}

--- a/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantCommand.cs
+++ b/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantCommand.cs
@@ -1,0 +1,31 @@
+using MediatR;
+using MyCRM.Auth.Application.DTOs;
+using MyCRM.Shared.Kernel.Results;
+
+namespace MyCRM.Auth.Application.Commands.Tenants.RegisterTenant;
+
+/// <summary>
+/// Registra um novo tenant criando em uma única operação:
+///   - Company (CRM)
+///   - Person / administrador (CRM)
+///   - Tenant (Auth)
+///   - User de acesso (Auth)
+///   - Role "Administrador" para o tenant (Auth)
+/// </summary>
+public record RegisterTenantCommand(
+    // ── Empresa ──────────────────────────────────────────────
+    string CompanyLegalName,
+    string? CompanyCnpj,
+    string? CompanyEmail,
+    string? CompanyPhone,
+
+    // ── Pessoa / administrador ────────────────────────────────
+    string AdminName,
+    string AdminEmail,
+    string? AdminCpf,
+    string? AdminPhone,
+
+    // ── Acesso ───────────────────────────────────────────────
+    string Password,
+    string PasswordConfirmation
+) : IRequest<Result<TenantDto>>;

--- a/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantHandler.cs
@@ -1,0 +1,110 @@
+using MediatR;
+using MyCRM.Auth.Application.DTOs;
+using MyCRM.Auth.Application.Services;
+using MyCRM.Auth.Domain.Entities;
+using MyCRM.Auth.Domain.Repositories;
+using MyCRM.Shared.Kernel.MultiTenancy;
+using MyCRM.Shared.Kernel.Results;
+using MyCRM.Shared.Kernel.Services;
+
+namespace MyCRM.Auth.Application.Commands.Tenants.RegisterTenant;
+
+public sealed class RegisterTenantHandler : IRequestHandler<RegisterTenantCommand, Result<TenantDto>>
+{
+    private readonly ITenantRepository _tenantRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IRoleRepository _roleRepository;
+    private readonly IPasswordHasher _passwordHasher;
+    private readonly ITenantService _tenantService;
+    private readonly ICrmTenantProvisioningService _crmProvisioning;
+
+    public RegisterTenantHandler(
+        ITenantRepository tenantRepository,
+        IUserRepository userRepository,
+        IRoleRepository roleRepository,
+        IPasswordHasher passwordHasher,
+        ITenantService tenantService,
+        ICrmTenantProvisioningService crmProvisioning)
+    {
+        _tenantRepository = tenantRepository;
+        _userRepository   = userRepository;
+        _roleRepository   = roleRepository;
+        _passwordHasher   = passwordHasher;
+        _tenantService    = tenantService;
+        _crmProvisioning  = crmProvisioning;
+    }
+
+    public async Task<Result<TenantDto>> Handle(RegisterTenantCommand request, CancellationToken ct)
+    {
+        // Gera o TenantId e define o contexto de tenant para toda a requisição.
+        // ITenantService é Scoped — SetTenant aqui afeta AuthDbContext e CRMDbContext
+        // na mesma requisição HTTP (sem JWT, sem claim tenant_id).
+        var newTenantId = Guid.NewGuid();
+        _tenantService.SetTenant(newTenantId);
+
+        // 1. Provisiona Company + Person no CRM (schema separado, mesmo banco)
+        TenantCrmData crmData;
+        try
+        {
+            crmData = await _crmProvisioning.ProvisionAsync(
+                tenantId:             newTenantId,
+                companyLegalName:     request.CompanyLegalName,
+                companyCnpj:          request.CompanyCnpj,
+                companyEmail:         request.CompanyEmail,
+                companyPhone:         request.CompanyPhone,
+                personFullName:       request.AdminName,
+                personEmail:          request.AdminEmail,
+                personDocumentNumber: request.AdminCpf,
+                personPhone:          request.AdminPhone,
+                ct:                   ct);
+        }
+        catch (Exception ex)
+        {
+            return Result<TenantDto>.Failure("TENANT_CRM_PROVISION_FAILED",
+                $"Failed to create company/person records: {ex.Message}");
+        }
+
+        // 2. Cria o Tenant com o Id pré-determinado (que será o TenantId do sistema)
+        var tenant = Tenant.Create(
+            name:          request.CompanyLegalName,
+            companyId:     crmData.CompanyId,
+            ownerPersonId: crmData.PersonId,
+            id:            newTenantId);
+
+        await _tenantRepository.AddAsync(tenant, ct);
+        await _tenantRepository.SaveChangesAsync(ct);
+
+        // 3. Cria o Role "Administrador" para o novo tenant
+        var adminRole = Role.Create(
+            tenantId:    newTenantId,
+            name:        "Administrador",
+            description: "Acesso total ao sistema.");
+
+        await _roleRepository.AddAsync(adminRole, ct);
+        await _roleRepository.SaveChangesAsync(ct);
+
+        // 4. Cria o usuário de acesso vinculado à Person CRM e ao Role admin
+        var passwordHash = _passwordHasher.Hash(request.Password);
+        var user = User.Create(
+            tenantId:     newTenantId,
+            name:         request.AdminName,
+            email:        request.AdminEmail,
+            passwordHash: passwordHash,
+            personId:     crmData.PersonId);
+
+        user.SyncRoles([adminRole.Id]);
+
+        await _userRepository.AddAsync(user, ct);
+        await _userRepository.SaveChangesAsync(ct);
+
+        return Result<TenantDto>.Success(new TenantDto(
+            tenant.Id,
+            tenant.Name,
+            tenant.CompanyId,
+            tenant.OwnerPersonId,
+            tenant.Status,
+            tenant.Plan,
+            tenant.CreatedAt,
+            tenant.UpdatedAt));
+    }
+}

--- a/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantValidator.cs
+++ b/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantValidator.cs
@@ -1,0 +1,45 @@
+using FluentValidation;
+
+namespace MyCRM.Auth.Application.Commands.Tenants.RegisterTenant;
+
+public sealed class RegisterTenantValidator : AbstractValidator<RegisterTenantCommand>
+{
+    public RegisterTenantValidator()
+    {
+        RuleFor(x => x.CompanyLegalName)
+            .NotEmpty()
+            .MaximumLength(300);
+
+        RuleFor(x => x.CompanyCnpj)
+            .MaximumLength(18)
+            .When(x => x.CompanyCnpj is not null);
+
+        RuleFor(x => x.CompanyEmail)
+            .EmailAddress()
+            .MaximumLength(254)
+            .When(x => x.CompanyEmail is not null);
+
+        RuleFor(x => x.AdminName)
+            .NotEmpty()
+            .MaximumLength(300);
+
+        RuleFor(x => x.AdminEmail)
+            .NotEmpty()
+            .EmailAddress()
+            .MaximumLength(254);
+
+        RuleFor(x => x.AdminCpf)
+            .MaximumLength(14)
+            .When(x => x.AdminCpf is not null);
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(8)
+            .MaximumLength(128);
+
+        RuleFor(x => x.PasswordConfirmation)
+            .NotEmpty()
+            .Equal(x => x.Password)
+            .WithMessage("Password confirmation does not match.");
+    }
+}

--- a/3 - Auth/Auth.Application/DTOs/TenantDto.cs
+++ b/3 - Auth/Auth.Application/DTOs/TenantDto.cs
@@ -1,0 +1,13 @@
+using MyCRM.Auth.Domain.Entities;
+
+namespace MyCRM.Auth.Application.DTOs;
+
+public record TenantDto(
+    Guid Id,
+    string Name,
+    Guid CompanyId,
+    Guid? OwnerPersonId,
+    TenantStatus Status,
+    TenantPlan Plan,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? UpdatedAt);

--- a/3 - Auth/Auth.Domain/Entities/Tenant.cs
+++ b/3 - Auth/Auth.Domain/Entities/Tenant.cs
@@ -1,0 +1,92 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.Auth.Domain.Entities;
+
+/// <summary>
+/// Tenant representa uma conta cliente isolada da plataforma MyCRM.
+///
+/// O Id desta entidade É o TenantId usado em todo o sistema — toda entidade
+/// tenant-aware armazena este Guid em sua coluna TenantId.
+///
+/// Herda de BaseEntity (não TenantEntity) porque é a própria raiz do tenant;
+/// não faz sentido filtrar tenants por TenantId.
+///
+/// Relacionamentos lógicos (sem FK física entre schemas):
+///   CompanyId  → crm.companies  (a empresa proprietária da conta)
+///   OwnerPersonId → crm.people  (a pessoa que registrou a conta)
+/// </summary>
+public sealed class Tenant : BaseEntity
+{
+    /// <summary>Nome de exibição do tenant (geralmente o nome da empresa).</summary>
+    public string Name { get; private set; } = default!;
+
+    /// <summary>
+    /// Referência lógica à empresa dona da conta (crm.companies).
+    /// Sem FK física — schemas independentes.
+    /// </summary>
+    public Guid CompanyId { get; private set; }
+
+    /// <summary>
+    /// Referência lógica à pessoa que registrou/administra a conta (crm.people).
+    /// Sem FK física — schemas independentes.
+    /// </summary>
+    public Guid? OwnerPersonId { get; private set; }
+
+    public TenantStatus Status { get; private set; }
+
+    public TenantPlan Plan { get; private set; }
+
+    private Tenant() { }
+
+    /// <summary>
+    /// Factory method — única forma de criar um novo Tenant.
+    /// O Id gerado aqui é o TenantId que será propagado para todas as entidades.
+    /// Passe <paramref name="id"/> explicitamente quando o TenantId precisar ser
+    /// pré-determinado (ex.: registro de tenant onde o Id é gerado antes de criar
+    /// User e Company para que o TenantId seja consistente desde o início).
+    /// </summary>
+    public static Tenant Create(
+        string name,
+        Guid companyId,
+        Guid? ownerPersonId = null,
+        TenantPlan plan = TenantPlan.Free,
+        Guid? id = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return new Tenant
+        {
+            Id            = id ?? Guid.NewGuid(),
+            Name          = name.Trim(),
+            CompanyId     = companyId,
+            OwnerPersonId = ownerPersonId,
+            Status        = TenantStatus.Trial,
+            Plan          = plan,
+        };
+    }
+
+    // ── Domain Methods ────────────────────────────────────────────────────────
+
+    public void Activate()  { Status = TenantStatus.Active;    Touch(); }
+    public void Suspend()   { Status = TenantStatus.Suspended; Touch(); }
+    public void Cancel()    { Status = TenantStatus.Cancelled; Touch(); }
+
+    public void UpdateName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        Name = name.Trim();
+        Touch();
+    }
+
+    public void SetOwnerPerson(Guid personId)
+    {
+        OwnerPersonId = personId;
+        Touch();
+    }
+
+    public void SetPlan(TenantPlan plan)
+    {
+        Plan = plan;
+        Touch();
+    }
+}

--- a/3 - Auth/Auth.Domain/Entities/TenantPlan.cs
+++ b/3 - Auth/Auth.Domain/Entities/TenantPlan.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.Auth.Domain.Entities;
+
+public enum TenantPlan
+{
+    Free    = 0,
+    Basic   = 1,
+    Premium = 2,
+}

--- a/3 - Auth/Auth.Domain/Entities/TenantStatus.cs
+++ b/3 - Auth/Auth.Domain/Entities/TenantStatus.cs
@@ -1,0 +1,9 @@
+namespace MyCRM.Auth.Domain.Entities;
+
+public enum TenantStatus
+{
+    Trial     = 0,
+    Active    = 1,
+    Suspended = 2,
+    Cancelled = 3,
+}

--- a/3 - Auth/Auth.Domain/Repositories/ITenantRepository.cs
+++ b/3 - Auth/Auth.Domain/Repositories/ITenantRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.Auth.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.Auth.Domain.Repositories;
+
+public interface ITenantRepository : IRepository<Tenant>
+{
+    new Task<Tenant?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<bool> NameExistsAsync(string name, Guid? excludeId = null, CancellationToken ct = default);
+}

--- a/3 - Auth/Auth.Infrastructure/DependencyInjection.cs
+++ b/3 - Auth/Auth.Infrastructure/DependencyInjection.cs
@@ -22,6 +22,7 @@ public static class DependencyInjection
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
         services.AddScoped<IRoleRepository, RoleRepository>();
         services.AddScoped<IPermissionRepository, PermissionRepository>();
+        services.AddScoped<ITenantRepository, TenantRepository>();
         services.AddScoped<IPermissionService, PermissionService>();
         services.AddSingleton<IPasswordHasher, BcryptPasswordHasher>();
         services.AddSingleton<ITokenGenerator, JwtTokenGenerator>();

--- a/3 - Auth/Auth.Infrastructure/Migrations/20260409130941_AddTenantEntity.Designer.cs
+++ b/3 - Auth/Auth.Infrastructure/Migrations/20260409130941_AddTenantEntity.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyCRM.Auth.Infrastructure.Persistence;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyCRM.Auth.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409130941_AddTenantEntity")]
+    partial class AddTenantEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/3 - Auth/Auth.Infrastructure/Migrations/20260409130941_AddTenantEntity.cs
+++ b/3 - Auth/Auth.Infrastructure/Migrations/20260409130941_AddTenantEntity.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyCRM.Auth.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTenantEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenants",
+                schema: "auth",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    CompanyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    OwnerPersonId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    Plan = table.Column<int>(type: "integer", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenants", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenants_CompanyId",
+                schema: "auth",
+                table: "tenants",
+                column: "CompanyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenants_Name",
+                schema: "auth",
+                table: "tenants",
+                column: "Name");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenants",
+                schema: "auth");
+        }
+    }
+}

--- a/3 - Auth/Auth.Infrastructure/Persistence/AuthDataSeeder.cs
+++ b/3 - Auth/Auth.Infrastructure/Persistence/AuthDataSeeder.cs
@@ -9,16 +9,45 @@ public static class AuthDataSeeder
     public static readonly Guid SeedTenantId = new("00000000-0000-0000-0000-000000000001");
 
     /// <summary>
-    /// Garante a existência do Role "Administrador", do usuário admin e do vínculo entre eles.
-    /// O adminPersonId vem do CRM seed — quem orquestra é o MigrationExtensions do Gateway.
+    /// Garante a existência do Tenant seed, do Role "Administrador", do usuário admin e vínculos.
+    /// adminPersonId e adminCompanyId vêm do CRM seed — orquestrado pelo MigrationExtensions.
     /// </summary>
-    public static async Task SeedAsync(AuthDbContext db, ITenantService tenantService, Guid? adminPersonId = null)
+    public static async Task SeedAsync(
+        AuthDbContext db,
+        ITenantService tenantService,
+        Guid? adminPersonId = null,
+        Guid? adminCompanyId = null)
     {
         tenantService.SetTenant(SeedTenantId);
+
+        await EnsureSeedTenantAsync(db, adminCompanyId, adminPersonId);
 
         var adminRole = await EnsureAdminRoleAsync(db);
         await EnsureAdminRoleHasAllPermissionsAsync(db, adminRole);
         await EnsureAdminUserAsync(db, adminRole, adminPersonId);
+    }
+
+    // ── Tenant Seed ───────────────────────────────────────────────────────────
+
+    private static async Task EnsureSeedTenantAsync(AuthDbContext db, Guid? companyId, Guid? personId)
+    {
+        var exists = await db.Tenants
+            .IgnoreQueryFilters()
+            .AnyAsync(t => t.Id == SeedTenantId);
+
+        if (exists)
+            return;
+
+        var tenant = Tenant.Create(
+            name:          "Mundo da Lua",
+            companyId:     companyId ?? Guid.Empty,
+            ownerPersonId: personId,
+            id:            SeedTenantId);
+
+        tenant.Activate();
+
+        await db.Tenants.AddAsync(tenant);
+        await db.SaveChangesAsync();
     }
 
     // ── Role Administrador ────────────────────────────────────────────────────

--- a/3 - Auth/Auth.Infrastructure/Persistence/AuthDbContext.cs
+++ b/3 - Auth/Auth.Infrastructure/Persistence/AuthDbContext.cs
@@ -24,6 +24,7 @@ public sealed class AuthDbContext : DbContext
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
     public DbSet<Permission> Permissions => Set<Permission>();
     public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
+    public DbSet<Tenant> Tenants => Set<Tenant>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -35,6 +36,10 @@ public sealed class AuthDbContext : DbContext
 
         modelBuilder.Entity<Role>()
             .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        // Tenant não é filtrado por TenantId (é a raiz do tenant); apenas soft-delete.
+        modelBuilder.Entity<Tenant>()
+            .HasQueryFilter(x => !x.IsDeleted);
 
         base.OnModelCreating(modelBuilder);
     }

--- a/3 - Auth/Auth.Infrastructure/Persistence/Configurations/TenantConfiguration.cs
+++ b/3 - Auth/Auth.Infrastructure/Persistence/Configurations/TenantConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MyCRM.Auth.Domain.Entities;
+
+namespace MyCRM.Auth.Infrastructure.Persistence.Configurations;
+
+public sealed class TenantConfiguration : IEntityTypeConfiguration<Tenant>
+{
+    public void Configure(EntityTypeBuilder<Tenant> builder)
+    {
+        builder.ToTable("tenants");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+
+        builder.Property(x => x.Name)
+            .IsRequired()
+            .HasMaxLength(300);
+
+        builder.Property(x => x.CompanyId).IsRequired();
+        builder.Property(x => x.OwnerPersonId);
+
+        builder.Property(x => x.Status)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(x => x.Plan)
+            .IsRequired()
+            .HasConversion<int>();
+
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        // Sem query filter por TenantId — Tenant é a raiz do tenant, não possui TenantId próprio.
+        // Filtro apenas para soft-delete.
+        builder.HasIndex(x => x.CompanyId);
+        builder.HasIndex(x => x.Name);
+    }
+}

--- a/3 - Auth/Auth.Infrastructure/Repositories/TenantRepository.cs
+++ b/3 - Auth/Auth.Infrastructure/Repositories/TenantRepository.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.Auth.Domain.Entities;
+using MyCRM.Auth.Domain.Repositories;
+using MyCRM.Auth.Infrastructure.Persistence;
+
+namespace MyCRM.Auth.Infrastructure.Repositories;
+
+public sealed class TenantRepository : ITenantRepository
+{
+    private readonly AuthDbContext _db;
+
+    public TenantRepository(AuthDbContext db) => _db = db;
+
+    public IQueryable<Tenant> Query() => _db.Tenants.AsQueryable();
+
+    public async Task<IReadOnlyList<Tenant>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.Tenants.AsNoTracking().Where(x => !x.IsDeleted).ToListAsync(ct);
+
+    public async Task<Tenant?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.Tenants.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted, ct);
+
+    public async Task<bool> NameExistsAsync(string name, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.Tenants.AnyAsync(x =>
+            !x.IsDeleted &&
+            x.Name == name &&
+            (excludeId == null || x.Id != excludeId.Value), ct);
+
+    public async Task AddAsync(Tenant entity, CancellationToken ct = default) =>
+        await _db.Tenants.AddAsync(entity, ct);
+
+    public void Update(Tenant entity) => _db.Tenants.Update(entity);
+
+    public void Delete(Tenant entity) => entity.SoftDelete();
+
+    public async Task<int> SaveChangesAsync(CancellationToken ct = default) =>
+        await _db.SaveChangesAsync(ct);
+}

--- a/3 - Shared/Shared.Kernel/Services/ICrmTenantProvisioningService.cs
+++ b/3 - Shared/Shared.Kernel/Services/ICrmTenantProvisioningService.cs
@@ -1,0 +1,26 @@
+namespace MyCRM.Shared.Kernel.Services;
+
+/// <summary>
+/// Cria os registros CRM (Company + Person) para um novo tenant.
+///
+/// A implementação reside em CRM.Infrastructure. A interface fica em Shared.Kernel
+/// para que Auth.Application possa depender dela sem criar referência circular.
+/// </summary>
+public interface ICrmTenantProvisioningService
+{
+    /// <summary>
+    /// Cria uma Company e uma Person no schema CRM usando o <paramref name="tenantId"/> fornecido.
+    /// Chama SetTenant internamente para que o CRMDbContext injete o TenantId correto.
+    /// </summary>
+    Task<TenantCrmData> ProvisionAsync(
+        Guid tenantId,
+        string companyLegalName,
+        string? companyCnpj,
+        string? companyEmail,
+        string? companyPhone,
+        string personFullName,
+        string personEmail,
+        string? personDocumentNumber,
+        string? personPhone,
+        CancellationToken ct = default);
+}

--- a/3 - Shared/Shared.Kernel/Services/TenantCrmData.cs
+++ b/3 - Shared/Shared.Kernel/Services/TenantCrmData.cs
@@ -1,0 +1,6 @@
+namespace MyCRM.Shared.Kernel.Services;
+
+/// <summary>
+/// Resultado do provisionamento CRM durante o registro de um novo tenant.
+/// </summary>
+public record TenantCrmData(Guid CompanyId, Guid PersonId);

--- a/3 - Shared/Shared.Kernel/SystemPermissions.cs
+++ b/3 - Shared/Shared.Kernel/SystemPermissions.cs
@@ -44,6 +44,7 @@ public static class SystemPermissions
 
     public const string UsersManage = "users:manage";
     public const string RolesManage = "roles:manage";
+    public const string TenantsManage = "tenants:manage";
 
     public static IReadOnlyList<(string Name, string Group)> All =>
     [
@@ -79,7 +80,8 @@ public static class SystemPermissions
         (CompaniesCreate, "Empresas"),
         (CompaniesUpdate, "Empresas"),
         (CompaniesDelete, "Empresas"),
-        (UsersManage, "Administração"),
-        (RolesManage, "Administração"),
+        (UsersManage,   "Administração"),
+        (RolesManage,   "Administração"),
+        (TenantsManage, "Administração"),
     ];
 }


### PR DESCRIPTION
## Summary
- Entidade `Tenant` (Auth.Domain) com enums `TenantStatus` e `TenantPlan`, herda de `BaseEntity` (não `TenantEntity` — é a própria raiz)
- `ITenantRepository` + `TenantRepository` + `TenantConfiguration` (EF Core) + migration `AddTenantEntity`
- `ICrmTenantProvisioningService` (Shared.Kernel) + `CrmTenantProvisioningService` (CRM.Infrastructure) — cria Company + Person no schema CRM durante o provisionamento
- `RegisterTenantCommand/Handler/Validator` (Auth.Application) — cria em uma única operação: Company, Person, Tenant, Role Administrador e User
- Mutation GraphQL `registerTenant` com `[AllowAnonymous]` (auto-cadastro público)
- `AuthDataSeeder` atualizado para garantir o Tenant seed (Mundo da Lua) via `EnsureSeedTenantAsync`
- `SystemPermissions.TenantsManage` adicionado em Shared.Kernel

## Test plan
- [ ] Aplicação sobe sem erros
- [ ] Migration `AddTenantEntity` aplicada com sucesso na tabela `auth.tenants`
- [ ] Mutation `registerTenant` disponível no schema GraphQL sem autenticação
- [ ] Fluxo completo: executar `registerTenant` cria Company + Person (CRM), Tenant + User + Role Administrador (Auth)
- [ ] Seed do Tenant `Mundo da Lua` criado na inicialização
- [ ] Permissão `tenants:manage` sincronizada via PermissionSeeder

🤖 Generated with [Claude Code](https://claude.com/claude-code)