### PR TITLE
feat(schema): exportar contrato GraphQL em SDL no CI/CD

### DIFF
--- a/.github/workflows/schema-export.yml
+++ b/.github/workflows/schema-export.yml
@@ -1,0 +1,68 @@
+name: Schema Export
+
+# Exporta o schema GraphQL em SDL e commita em contracts/schema.graphql.
+# O front-end consome esse arquivo como fonte de verdade para o codegen,
+# sem depender do endpoint ao vivo.
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  workflow_dispatch:
+
+jobs:
+  export:
+    name: Export GraphQL Schema
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Necessário para poder commitar de volta
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: nuget-
+
+      - name: Restore dependencies
+        run: dotnet restore MyCRM.sln
+
+      - name: Build
+        run: dotnet build MyCRM.sln --no-restore --configuration Release
+
+      - name: Export schema
+        run: |
+          dotnet run \
+            --project "1 - Gateway/MundoDaLua.GraphQL/MyCRM.GraphQL.csproj" \
+            --no-build \
+            --configuration Release \
+            -- --export-schema --output contracts/schema.graphql
+
+      - name: Upload schema artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: graphql-schema-${{ github.ref_name }}
+          path: contracts/schema.graphql
+          retention-days: 90
+
+      - name: Commit schema to repository
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add contracts/schema.graphql
+          git diff --staged --quiet && echo "Schema sem alterações." && exit 0
+          git commit -m "chore: atualizar contracts/schema.graphql [skip ci]"
+          git push

--- a/1 - Gateway/MundoDaLua.GraphQL/Extensions/SchemaExporter.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/Extensions/SchemaExporter.cs
@@ -1,0 +1,91 @@
+using HotChocolate.Execution;
+using Microsoft.Extensions.DependencyInjection;
+using MyCRM.GraphQL.GraphQL.Enums;
+using MyCRM.GraphQL.GraphQL.Students.Types;
+
+namespace MyCRM.GraphQL.Extensions;
+
+/// <summary>
+/// Exporta o schema GraphQL em SDL sem precisar de banco de dados ou infraestrutura.
+/// Usado no CI/CD para gerar o contrato GraphQL que o front-end consome via codegen.
+///
+/// Invocação: dotnet run -- --export-schema [--output caminho/schema.graphql]
+/// </summary>
+public static class SchemaExporter
+{
+    public static async Task ExportAsync(string outputPath = "schema.graphql")
+    {
+        Console.WriteLine("Iniciando exportação do schema GraphQL...");
+
+        var services = new ServiceCollection();
+
+        // Autorização mínima para [Authorize(Policy = ...)] ser processado pelo HC
+        services.AddAuthorization();
+        services.AddLogging();
+
+        services
+            .AddGraphQLServer()
+            .AddQueryType()
+            .AddMutationType()
+            // CRM
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Customers.CustomerQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Customers.CustomerMutations>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.People.PersonQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.People.PersonMutations>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Companies.CompanyQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Companies.CompanyMutations>()
+            // Auth
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Auth.AuthMutations>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Auth.UserQueries>()
+            .AddType<MyCRM.GraphQL.GraphQL.Auth.UserObjectType>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Auth.RoleQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Auth.RoleMutations>()
+            .AddType<MyCRM.GraphQL.GraphQL.Auth.RoleObjectType>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Auth.PermissionQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Auth.PermissionAdminQueries>()
+            // Students
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Students.StudentQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Students.StudentMutations>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Students.StudentObjectTypeExtension>()
+            .AddType<StudentEnrollmentStatusType>()
+            .AddType<StudentCourseStatusType>()
+            .AddType<StudentFilterType>()
+            .AddType<StudentSortType>()
+            // Student Guardians
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.StudentGuardians.StudentGuardianQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.StudentGuardians.StudentGuardianMutations>()
+            // Courses
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Courses.CourseQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Courses.CourseMutations>()
+            // Student Courses
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.StudentCourses.StudentCourseQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.StudentCourses.StudentCourseMutations>()
+            // Employees
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Employees.EmployeeQueries>()
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Employees.EmployeeMutations>()
+            // Tenants
+            .AddTypeExtension<MyCRM.GraphQL.GraphQL.Tenants.TenantMutations>()
+            // Shared types
+            .AddType<MyCRM.GraphQL.GraphQL.Customers.CustomerObjectType>()
+            // Capabilities
+            .AddAuthorization()
+            .AddFiltering()
+            .AddSorting()
+            .AddProjections();
+
+        await using var provider = services.BuildServiceProvider();
+
+        var resolver = provider.GetRequiredService<IRequestExecutorResolver>();
+        var executor = await resolver.GetRequestExecutorAsync();
+
+        var sdl = executor.Schema.ToString();
+
+        var directory = System.IO.Path.GetDirectoryName(outputPath);
+        if (!string.IsNullOrEmpty(directory))
+            System.IO.Directory.CreateDirectory(directory);
+
+        await System.IO.File.WriteAllTextAsync(outputPath, sdl);
+
+        Console.WriteLine($"Schema exportado: {System.IO.Path.GetFullPath(outputPath)}");
+    }
+}

--- a/1 - Gateway/MundoDaLua.GraphQL/Program.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/Program.cs
@@ -20,6 +20,16 @@ using Serilog;
 using System.Text;
 using System.Threading.RateLimiting;
 
+// Modo de exportação de schema — sem DB, sem JWT, sem infraestrutura.
+// Usado no CI/CD para gerar contracts/schema.graphql.
+if (args.Contains("--export-schema"))
+{
+    var outputPath = args.SkipWhile(a => a != "--output").Skip(1).FirstOrDefault()
+        ?? "schema.graphql";
+    await MyCRM.GraphQL.Extensions.SchemaExporter.ExportAsync(outputPath);
+    return;
+}
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((ctx, cfg) =>


### PR DESCRIPTION
## Summary
- Adiciona `SchemaExporter.cs`: host mínimo Hot Chocolate (sem DB, sem JWT) que exporta o schema em SDL via `IRequestExecutorResolver`
- Adiciona modo `--export-schema [--output path]` no `Program.cs` — retorna antes de qualquer validação de infraestrutura
- Cria workflow `schema-export.yml`: roda no push em `dev`/`main`, exporta o schema, commita `contracts/schema.graphql` de volta com `[skip ci]` e sobe como artifact (90 dias)

## Como funciona
O Hot Chocolate constrói o schema via reflection das assinaturas de método — sem instanciar resolvers e sem acessar banco. Os `[Service]` nos parâmetros são injeção por campo (runtime), não por construtor. Portanto o export funciona 100% sem infraestrutura.

## Para o front-end
O arquivo `contracts/schema.graphql` fica sempre atualizado no branch `dev` e pode ser referenciado diretamente pelo `codegen.ts`:
```ts
// codegen.ts
const config: CodegenConfig = {
  schema: './contracts/schema.graphql', // ou URL do artifact no CI
  ...
}
```

## Test plan
- [x] Build sem erros (`dotnet build`)
- [x] Export local validado: 1940 linhas, schema completo gerado sem banco de dados
- [ ] Workflow executa no push em `dev` e commita `contracts/schema.graphql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)