### PR TITLE
fix(schema-export): corrigir caminho do schema.graphql no CI

### DIFF
--- a/.github/workflows/schema-export.yml
+++ b/.github/workflows/schema-export.yml
@@ -48,8 +48,9 @@ jobs:
           dotnet run \
             --project "1 - Gateway/MundoDaLua.GraphQL/MyCRM.GraphQL.csproj" \
             --no-build \
+            --no-launch-profile \
             --configuration Release \
-            -- --export-schema --output contracts/schema.graphql
+            -- --export-schema --output "$GITHUB_WORKSPACE/contracts/schema.graphql"
 
       - name: Upload schema artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Adiciona `--no-launch-profile` ao `dotnet run` para evitar que o `launchSettings.json` altere o working directory do processo
- Usa `$GITHUB_WORKSPACE/contracts/schema.graphql` como caminho absoluto, garantindo que o arquivo seja criado no local correto independente do runtime directory

## Root cause
O `dotnet run` carrega automaticamente o `launchSettings.json` do projeto, que pode definir um `workingDirectory` diferente do diretório do repositório. Isso fazia o `schema.graphql` ser criado em outro local, e o `git add contracts/schema.graphql` falhava com `pathspec did not match any files`.

## Test plan
- [ ] Workflow executa sem erro após merge em `dev`
- [ ] `contracts/schema.graphql` é criado e commitado corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)