### PR TITLE
feat(auth): campo IsAdmin no usuário com bypass de RBAC e claim no JWT

### DIFF
--- a/1 - Gateway/MundoDaLua.GraphQL/Authorization/PermissionAuthorizationHandler.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/Authorization/PermissionAuthorizationHandler.cs
@@ -23,6 +23,13 @@ public sealed class PermissionAuthorizationHandler : AuthorizationHandler<Permis
         if (userId is null || !Guid.TryParse(userId, out var userGuid))
             return;
 
+        var isAdmin = context.User.FindFirstValue("is_admin") == "true";
+        if (isAdmin)
+        {
+            context.Succeed(requirement);
+            return;
+        }
+
         var has = await _permissionService.HasPermissionAsync(userGuid, requirement.Permission);
         if (has)
             context.Succeed(requirement);

--- a/3 - Auth/Auth.Application/Commands/Login/LoginHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/Login/LoginHandler.cs
@@ -80,6 +80,7 @@ public sealed class LoginHandler : IRequestHandler<LoginCommand, Result<LoginDto
             user.Name,
             user.Email,
             rawRefreshToken,
-            refreshExpiresAt));
+            refreshExpiresAt,
+            user.IsAdmin));
     }
 }

--- a/3 - Auth/Auth.Application/Commands/LoginByEmail/LoginByEmailHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/LoginByEmail/LoginByEmailHandler.cs
@@ -78,6 +78,7 @@ public sealed class LoginByEmailHandler : IRequestHandler<LoginByEmailCommand, R
             user.Name,
             user.Email,
             rawRefreshToken,
-            refreshExpiresAt));
+            refreshExpiresAt,
+            user.IsAdmin));
     }
 }

--- a/3 - Auth/Auth.Application/Commands/RefreshToken/RefreshTokenHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/RefreshToken/RefreshTokenHandler.cs
@@ -66,7 +66,8 @@ public sealed class RefreshTokenHandler : IRequestHandler<RefreshTokenCommand, R
             user.Name,
             user.Email,
             rawRefreshToken,
-            refreshExpiresAt));
+            refreshExpiresAt,
+            user.IsAdmin));
     }
 
     private static string ComputeHash(string rawToken)

--- a/3 - Auth/Auth.Application/Commands/Users/CreateUser/CreateUserHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/Users/CreateUser/CreateUserHandler.cs
@@ -64,6 +64,7 @@ public sealed class CreateUserHandler : IRequestHandler<CreateUserCommand, Resul
             user.Name,
             user.Email,
             user.IsActive,
+            user.IsAdmin,
             user.PersonId,
             user.CreatedAt,
             user.UpdatedAt,

--- a/3 - Auth/Auth.Application/Commands/Users/UpdateUser/UpdateUserHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/Users/UpdateUser/UpdateUserHandler.cs
@@ -68,6 +68,7 @@ public sealed class UpdateUserHandler : IRequestHandler<UpdateUserCommand, Resul
             user.Name,
             user.Email,
             user.IsActive,
+            user.IsAdmin,
             user.PersonId,
             user.CreatedAt,
             user.UpdatedAt,

--- a/3 - Auth/Auth.Application/DTOs/LoginDto.cs
+++ b/3 - Auth/Auth.Application/DTOs/LoginDto.cs
@@ -7,4 +7,5 @@ public record LoginDto(
     string Name,
     string Email,
     string RefreshToken,
-    DateTimeOffset RefreshTokenExpiresAt);
+    DateTimeOffset RefreshTokenExpiresAt,
+    bool IsAdmin);

--- a/3 - Auth/Auth.Application/DTOs/UserDto.cs
+++ b/3 - Auth/Auth.Application/DTOs/UserDto.cs
@@ -6,6 +6,7 @@ public record UserDto(
     string Name,
     string Email,
     bool IsActive,
+    bool IsAdmin,
     Guid? PersonId,
     DateTimeOffset CreatedAt,
     DateTimeOffset? UpdatedAt,

--- a/3 - Auth/Auth.Domain/Entities/User.cs
+++ b/3 - Auth/Auth.Domain/Entities/User.cs
@@ -8,6 +8,7 @@ public class User : TenantEntity
     public string PasswordHash { get; private set; } = default!;
     public string Name { get; private set; } = default!;
     public bool IsActive { get; private set; }
+    public bool IsAdmin { get; private set; }
 
     private readonly List<UserRole> _userRoles = [];
     public IReadOnlyCollection<UserRole> UserRoles => _userRoles.AsReadOnly();
@@ -78,4 +79,7 @@ public class User : TenantEntity
 
     public void Deactivate() { IsActive = false; Touch(); }
     public void Activate() { IsActive = true; Touch(); }
+
+    public void SetAdmin() { IsAdmin = true; Touch(); }
+    public void UnsetAdmin() { IsAdmin = false; Touch(); }
 }

--- a/3 - Auth/Auth.Infrastructure/Migrations/20260410104709_AddUserIsAdmin.Designer.cs
+++ b/3 - Auth/Auth.Infrastructure/Migrations/20260410104709_AddUserIsAdmin.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyCRM.Auth.Infrastructure.Persistence;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyCRM.Auth.Infrastructure.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410104709_AddUserIsAdmin")]
+    partial class AddUserIsAdmin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/3 - Auth/Auth.Infrastructure/Migrations/20260410104709_AddUserIsAdmin.cs
+++ b/3 - Auth/Auth.Infrastructure/Migrations/20260410104709_AddUserIsAdmin.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyCRM.Auth.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserIsAdmin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAdmin",
+                schema: "auth",
+                table: "users",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAdmin",
+                schema: "auth",
+                table: "users");
+        }
+    }
+}

--- a/3 - Auth/Auth.Infrastructure/Persistence/AuthDataSeeder.cs
+++ b/3 - Auth/Auth.Infrastructure/Persistence/AuthDataSeeder.cs
@@ -112,6 +112,8 @@ public static class AuthDataSeeder
                 user.LinkToPerson(adminPersonId.Value);
         }
 
+        user.SetAdmin();
+
         await db.SaveChangesAsync();
 
         // Garante que o role Administrador está atribuído

--- a/3 - Auth/Auth.Infrastructure/Persistence/Configurations/UserConfiguration.cs
+++ b/3 - Auth/Auth.Infrastructure/Persistence/Configurations/UserConfiguration.cs
@@ -16,6 +16,7 @@ public sealed class UserConfiguration : IEntityTypeConfiguration<User>
         builder.Property(x => x.Email).IsRequired().HasMaxLength(254);
         builder.Property(x => x.PasswordHash).IsRequired().HasMaxLength(512);
         builder.Property(x => x.IsActive).IsRequired().HasDefaultValue(true);
+        builder.Property(x => x.IsAdmin).IsRequired().HasDefaultValue(false);
         builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
         builder.Property(x => x.CreatedAt).IsRequired();
 

--- a/3 - Auth/Auth.Infrastructure/Services/JwtTokenGenerator.cs
+++ b/3 - Auth/Auth.Infrastructure/Services/JwtTokenGenerator.cs
@@ -26,6 +26,7 @@ public sealed class JwtTokenGenerator : ITokenGenerator
             new Claim(JwtRegisteredClaimNames.Email, user.Email),
             new Claim("tenant_id", user.TenantId.ToString()),
             new Claim("name", user.Name),
+            new Claim("is_admin", user.IsAdmin ? "true" : "false"),
         };
 
         var token = new JwtSecurityToken(

--- a/4 - Tests/UnitTests/GraphQL/AllEntitiesRbacRegressionTests.cs
+++ b/4 - Tests/UnitTests/GraphQL/AllEntitiesRbacRegressionTests.cs
@@ -1090,7 +1090,7 @@ public sealed class AllEntitiesRbacRegressionTests
     {
         var userId = Guid.NewGuid();
         var dto = new UserDto(
-            Guid.NewGuid(), TenantId, "User Test", "user@test.com", true,
+            Guid.NewGuid(), TenantId, "User Test", "user@test.com", true, false,
             null, DateTimeOffset.UtcNow, null, null, null);
 
         var mediator = Substitute.For<IMediator>();
@@ -1133,7 +1133,7 @@ public sealed class AllEntitiesRbacRegressionTests
     {
         var userId = Guid.NewGuid();
         var dto = new UserDto(
-            Guid.NewGuid(), TenantId, "User Updated", "updated@test.com", true,
+            Guid.NewGuid(), TenantId, "User Updated", "updated@test.com", true, false,
             null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, null, null);
 
         var mediator = Substitute.For<IMediator>();

--- a/4 - Tests/UnitTests/GraphQL/AuthMutationTests.cs
+++ b/4 - Tests/UnitTests/GraphQL/AuthMutationTests.cs
@@ -109,7 +109,8 @@ public sealed class AuthMutationTests
             Name: "Test User",
             Email: "test@test.com",
             RefreshToken: "new-refresh-token",
-            RefreshTokenExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+            RefreshTokenExpiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            IsAdmin: false);
 
         mediator.Send(Arg.Any<RefreshTokenCommand>(), Arg.Any<CancellationToken>())
             .Returns(MyCRM.Shared.Kernel.Results.Result<LoginDto>.Success(dto));
@@ -140,7 +141,8 @@ public sealed class AuthMutationTests
             Name: "Test User",
             Email: "test@test.com",
             RefreshToken: "refresh-token-value",
-            RefreshTokenExpiresAt: DateTimeOffset.UtcNow.AddDays(30));
+            RefreshTokenExpiresAt: DateTimeOffset.UtcNow.AddDays(30),
+            IsAdmin: false);
 
         mediator.Send(Arg.Any<LoginCommand>(), Arg.Any<CancellationToken>())
             .Returns(MyCRM.Shared.Kernel.Results.Result<LoginDto>.Success(dto));
@@ -236,6 +238,7 @@ public sealed class AuthMutationTests
             Name: "Maria",
             Email: "maria@test.com",
             IsActive: true,
+            IsAdmin: false,
             PersonId: null,
             CreatedAt: DateTimeOffset.UtcNow,
             UpdatedAt: null,
@@ -271,6 +274,7 @@ public sealed class AuthMutationTests
             Name: "Maria",
             Email: "maria@test.com",
             IsActive: true,
+            IsAdmin: false,
             PersonId: null,
             CreatedAt: DateTimeOffset.UtcNow,
             UpdatedAt: null,
@@ -308,6 +312,7 @@ public sealed class AuthMutationTests
             Name: "Maria Atualizada",
             Email: "maria.atualizada@test.com",
             IsActive: false,
+            IsAdmin: false,
             PersonId: null,
             CreatedAt: DateTimeOffset.UtcNow.AddDays(-1),
             UpdatedAt: DateTimeOffset.UtcNow,


### PR DESCRIPTION
## Summary
- Adiciona `User.IsAdmin` (bool, default `false`) na entidade e na tabela `auth.users`
- Usuário admin seed (`AuthDataSeeder`) nasce com `IsAdmin = true`
- JWT inclui claim `is_admin` — lido diretamente do token, sem hit adicional no banco
- `PermissionAuthorizationHandler` faz **bypass total de RBAC** quando `is_admin == true`
- `LoginDto` e `UserDto` expõem `IsAdmin` para que o frontend leia diretamente, sem inferir pelo conjunto de permissões
- Métodos `SetAdmin()` / `UnsetAdmin()` disponíveis na entidade para uso futuro

## Test plan
- [ ] Migration aplicada com sucesso (`auth.users` ganha coluna `is_admin boolean default false`)
- [ ] Seed re-executado: usuário `admin@mundodalua.com` tem `is_admin = true` no banco
- [ ] Token JWT do admin contém claim `is_admin: true`
- [ ] Admin acessa qualquer resolver protegido sem precisar ter permissão explícita
- [ ] Usuário não-admin continua passando pelo RBAC normalmente
- [ ] `dotnet test` passa sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)