### PR TITLE
fix(auth): expor isAdmin no UpdateUserInput e UserObjectType

### DIFF
--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/AuthMutations.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/AuthMutations.cs
@@ -46,6 +46,7 @@ public class AuthMutations
             input.Email,
             input.PersonId,
             input.IsActive,
+            input.IsAdmin,
             input.Password,
             input.RoleIds), ct);
 

--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/Inputs/UpdateUserInput.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/Inputs/UpdateUserInput.cs
@@ -5,6 +5,7 @@ public record UpdateUserInput(
     string Email,
     Guid? PersonId,
     bool IsActive,
+    bool IsAdmin,
     string? Password,
     IReadOnlyList<Guid>? RoleIds = null
 );

--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/UserObjectType.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/UserObjectType.cs
@@ -13,6 +13,7 @@ public sealed class UserObjectType : ObjectType<User>
         descriptor.Field(x => x.Name);
         descriptor.Field(x => x.Email);
         descriptor.Field(x => x.IsActive);
+        descriptor.Field(x => x.IsAdmin);
         descriptor.Field(x => x.CreatedAt);
         descriptor.Field(x => x.UpdatedAt);
         descriptor.Field(x => x.CreatedBy);

--- a/3 - Auth/Auth.Application/Commands/Users/UpdateUser/UpdateUserCommand.cs
+++ b/3 - Auth/Auth.Application/Commands/Users/UpdateUser/UpdateUserCommand.cs
@@ -10,6 +10,7 @@ public record UpdateUserCommand(
     string Email,
     Guid? PersonId,
     bool IsActive,
+    bool IsAdmin,
     string? Password,
     IReadOnlyList<Guid>? RoleIds = null
 ) : IRequest<Result<UserDto>>;

--- a/3 - Auth/Auth.Application/Commands/Users/UpdateUser/UpdateUserHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/Users/UpdateUser/UpdateUserHandler.cs
@@ -52,6 +52,9 @@ public sealed class UpdateUserHandler : IRequestHandler<UpdateUserCommand, Resul
 
         user.UpdateProfile(request.Name, request.Email, request.PersonId, request.IsActive);
 
+        if (request.IsAdmin) user.SetAdmin();
+        else user.UnsetAdmin();
+
         if (!string.IsNullOrWhiteSpace(request.Password))
             user.UpdatePassword(_passwordHasher.Hash(request.Password));
 

--- a/4 - Tests/UnitTests/Auth/UpdateUserHandlerTests.cs
+++ b/4 - Tests/UnitTests/Auth/UpdateUserHandlerTests.cs
@@ -29,7 +29,7 @@ public sealed class UpdateUserHandlerTests
         _userRepository.GetByIdWithRolesAsync(Arg.Any<Guid>(), default).Returns((User?)null);
 
         var result = await _handler.Handle(
-            new UpdateUserCommand(Guid.NewGuid(), "Maria", "maria@test.com", null, true, null),
+            new UpdateUserCommand(Guid.NewGuid(), "Maria", "maria@test.com", null, true, false, null),
             default);
 
         Assert.False(result.IsSuccess);
@@ -44,7 +44,7 @@ public sealed class UpdateUserHandlerTests
         _userRepository.EmailExistsAsync(_tenantId, "other@test.com", user.Id, default).Returns(true);
 
         var result = await _handler.Handle(
-            new UpdateUserCommand(user.Id, "Maria", "other@test.com", null, true, null),
+            new UpdateUserCommand(user.Id, "Maria", "other@test.com", null, true, false, null),
             default);
 
         Assert.False(result.IsSuccess);
@@ -70,6 +70,7 @@ public sealed class UpdateUserHandlerTests
                 "Maria Nova",
                 "maria.nova@test.com",
                 Guid.NewGuid(),
+                false,
                 false,
                 "NovaSenha123!",
                 [tenantRole.Id]),
@@ -97,7 +98,7 @@ public sealed class UpdateUserHandlerTests
             .Returns([Role.Create(Guid.NewGuid(), "Professor")]);
 
         var result = await _handler.Handle(
-            new UpdateUserCommand(user.Id, "Maria", "maria@test.com", null, true, null, [roleId]),
+            new UpdateUserCommand(user.Id, "Maria", "maria@test.com", null, true, false, null, [roleId]),
             default);
 
         Assert.False(result.IsSuccess);
@@ -116,7 +117,7 @@ public sealed class UpdateUserHandlerTests
         _roleRepository.GetByIdsIgnoringQueryFiltersAsync(Arg.Any<IReadOnlyCollection<Guid>>(), default).Returns([]);
 
         var result = await _handler.Handle(
-            new UpdateUserCommand(user.Id, "Maria", "maria@test.com", null, true, null, [roleId]),
+            new UpdateUserCommand(user.Id, "Maria", "maria@test.com", null, true, false, null, [roleId]),
             default);
 
         Assert.False(result.IsSuccess);


### PR DESCRIPTION
## Summary
- Campo `isAdmin` faltava no `UpdateUserInput` — causava erro no GraphQL
- `UpdateUserCommand` e handler atualizados para receber e aplicar o campo
- `UserObjectType` agora expõe `isAdmin` no schema
- Testes corrigidos para o novo parâmetro posicional

## Test plan
- [ ] `updateUser(input: { ..., isAdmin: true })` aceito pelo schema
- [ ] Usuário com `isAdmin: true` tem bypass de RBAC no próximo login
- [ ] `dotnet test` passa sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)