### PR TITLE
feat(auth): expor usersCount na listagem de Role

### DIFF
--- a/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/RoleObjectType.cs
+++ b/1 - Gateway/MundoDaLua.GraphQL/GraphQL/Auth/RoleObjectType.cs
@@ -37,6 +37,19 @@ public sealed class RoleObjectType : ObjectType<Role>
                         rp.Permission.IsActive))
                     .ToListAsync(context.RequestAborted);
             });
+        descriptor
+            .Field("usersCount")
+            .Type<NonNullType<IntType>>()
+            .Resolve(async context =>
+            {
+                var db = context.Service<AuthDbContext>();
+                var role = context.Parent<Role>();
+
+                return await db.UserRoles
+                    .AsNoTracking()
+                    .CountAsync(ur => ur.RoleId == role.Id, context.RequestAborted);
+            });
+
         descriptor.Ignore(x => x.TenantId);
         descriptor.Ignore(x => x.IsDeleted);
         descriptor.Ignore(x => x.DeletedAt);


### PR DESCRIPTION
## Summary
- Adiciona campo `usersCount: Int!` no tipo `Role` do schema GraphQL
- Resolvido via `COUNT` na tabela `user_roles` — mesma abordagem já usada pelo campo `permissions`
- Disponível em `getRoles` e `getRoleById`

## Uso
\`\`\`graphql
query {
  roles {
    nodes {
      id
      name
      usersCount
    }
  }
}
\`\`\`

## Test plan
- [ ] Campo `usersCount` aparece no schema
- [ ] Retorna 0 para roles sem usuários
- [ ] Retorna contagem correta para roles com usuários

🤖 Generated with [Claude Code](https://claude.com/claude-code)