### PR TITLE
fix(tenant): corrige soft-delete que não persistia no banco

### DIFF
--- a/3 - Auth/Auth.Infrastructure/Repositories/TenantRepository.cs
+++ b/3 - Auth/Auth.Infrastructure/Repositories/TenantRepository.cs
@@ -17,7 +17,7 @@ public sealed class TenantRepository : ITenantRepository
         await _db.Tenants.AsNoTracking().Where(x => !x.IsDeleted).ToListAsync(ct);
 
     public async Task<Tenant?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
-        await _db.Tenants.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted, ct);
+        await _db.Tenants.FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted, ct);
 
     public async Task<bool> NameExistsAsync(string name, Guid? excludeId = null, CancellationToken ct = default) =>
         await _db.Tenants.AnyAsync(x =>

--- a/4 - Tests/UnitTests/Auth/DeleteTenantHandlerTests.cs
+++ b/4 - Tests/UnitTests/Auth/DeleteTenantHandlerTests.cs
@@ -49,4 +49,17 @@ public sealed class DeleteTenantHandlerTests
         _repository.DidNotReceive().Delete(Arg.Any<Tenant>());
         await _repository.DidNotReceive().SaveChangesAsync(default);
     }
+
+    [Fact]
+    public async Task Handle_ExistingTenant_SoftDeletesEntity()
+    {
+        var tenant = Tenant.Create("Acme Ltda", Guid.NewGuid());
+        _repository.GetByIdAsync(tenant.Id, default).Returns(tenant);
+        _repository.When(r => r.Delete(Arg.Any<Tenant>())).Do(ci => ci.Arg<Tenant>().SoftDelete());
+
+        await _handler.Handle(new DeleteTenantCommand(tenant.Id), default);
+
+        Assert.True(tenant.IsDeleted);
+        Assert.NotNull(tenant.DeletedAt);
+    }
 }


### PR DESCRIPTION
## Summary
- `TenantRepository.GetByIdAsync` usava `AsNoTracking()`, carregando a entidade sem tracking do EF Core
- `Delete()` chamava `entity.SoftDelete()` que alterava `IsDeleted`/`DeletedAt` apenas em memória — o change tracker não detectava nenhuma mudança e `SaveChangesAsync` não persistia nada
- Removido `AsNoTracking()` para alinhar com o padrão de `UserRepository`, `RoleRepository` e `CustomerRepository`
- Adicionado teste que verifica `IsDeleted = true` e `DeletedAt != null` após a deleção

## Validação
- Build: dotnet build ✅
- Testes: dotnet test ✅ (236 passando)
- Migration: não necessária

## Test plan
- [ ] `deleteTenant` retorna `true`
- [ ] Após deletar, `tenantById` retorna `null`
- [ ] Após deletar, `tenants(where: { isDeleted: { eq: false } })` não traz o registro
- [ ] `isDeleted = true` e `deletedAt` preenchido no banco

🤖 Generated with [Claude Code](https://claude.com/claude-code)