### PR TITLE
feat(email): email transacional com Resend

### DIFF
--- a/1 - Gateway/MundoDaLua.GraphQL/appsettings.json
+++ b/1 - Gateway/MundoDaLua.GraphQL/appsettings.json
@@ -43,6 +43,11 @@
       }
     ]
   },
+  "Resend": {
+    "ApiKey": "",
+    "FromEmail": "noreply@mundodalua.com.br",
+    "FromName": "Mundo da Lua CRM"
+  },
   "AllowedHosts": "*",
   "Cors": {
     "AllowedOrigins": []

--- a/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantHandler.cs
+++ b/3 - Auth/Auth.Application/Commands/Tenants/RegisterTenant/RegisterTenantHandler.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.Extensions.Logging;
 using MyCRM.Auth.Application.DTOs;
 using MyCRM.Auth.Application.Services;
 using MyCRM.Auth.Domain.Entities;
@@ -18,6 +19,8 @@ public sealed class RegisterTenantHandler : IRequestHandler<RegisterTenantComman
     private readonly IPasswordHasher _passwordHasher;
     private readonly ITenantService _tenantService;
     private readonly ICrmTenantProvisioningService _crmProvisioning;
+    private readonly IEmailSender _emailSender;
+    private readonly ILogger<RegisterTenantHandler> _logger;
 
     public RegisterTenantHandler(
         ITenantRepository tenantRepository,
@@ -26,7 +29,9 @@ public sealed class RegisterTenantHandler : IRequestHandler<RegisterTenantComman
         IPermissionRepository permissionRepository,
         IPasswordHasher passwordHasher,
         ITenantService tenantService,
-        ICrmTenantProvisioningService crmProvisioning)
+        ICrmTenantProvisioningService crmProvisioning,
+        IEmailSender emailSender,
+        ILogger<RegisterTenantHandler> logger)
     {
         _tenantRepository     = tenantRepository;
         _userRepository       = userRepository;
@@ -35,6 +40,8 @@ public sealed class RegisterTenantHandler : IRequestHandler<RegisterTenantComman
         _passwordHasher       = passwordHasher;
         _tenantService        = tenantService;
         _crmProvisioning      = crmProvisioning;
+        _emailSender          = emailSender;
+        _logger               = logger;
     }
 
     public async Task<Result<TenantDto>> Handle(RegisterTenantCommand request, CancellationToken ct)
@@ -102,6 +109,27 @@ public sealed class RegisterTenantHandler : IRequestHandler<RegisterTenantComman
 
         await _userRepository.AddAsync(user, ct);
         await _userRepository.SaveChangesAsync(ct);
+
+        // 5. Envia email de boas-vindas (falha não impede o registro)
+        try
+        {
+            var htmlBody = $"""
+                <h1>Bem-vindo ao Mundo da Lua CRM, {request.AdminName}!</h1>
+                <p>Sua empresa <strong>{request.CompanyLegalName}</strong> foi registrada com sucesso.</p>
+                <p>Você já pode acessar o sistema com o e-mail <strong>{request.AdminEmail}</strong>.</p>
+                <p>Qualquer dúvida, entre em contato com o suporte.</p>
+                """;
+
+            await _emailSender.SendAsync(new EmailMessage(
+                To:       request.AdminEmail,
+                Subject:  $"Bem-vindo ao Mundo da Lua CRM — {request.CompanyLegalName}",
+                HtmlBody: htmlBody,
+                ToName:   request.AdminName), ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Falha ao enviar email de boas-vindas para {Email}", request.AdminEmail);
+        }
 
         return Result<TenantDto>.Success(new TenantDto(
             tenant.Id,

--- a/3 - Auth/Auth.Infrastructure/DependencyInjection.cs
+++ b/3 - Auth/Auth.Infrastructure/DependencyInjection.cs
@@ -3,9 +3,11 @@ using MyCRM.Auth.Domain.Repositories;
 using MyCRM.Auth.Infrastructure.Persistence;
 using MyCRM.Auth.Infrastructure.Repositories;
 using MyCRM.Auth.Infrastructure.Services;
+using MyCRM.Shared.Kernel.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Resend;
 
 namespace MyCRM.Auth.Infrastructure;
 
@@ -29,6 +31,17 @@ public static class DependencyInjection
         services.AddSingleton<IRefreshTokenGenerator, RefreshTokenGenerator>();
         services.AddMemoryCache();
         services.AddSingleton<ILoginAttemptTracker, MemoryCacheLoginAttemptTracker>();
+
+        // Email
+        services.Configure<ResendSettings>(configuration.GetSection("Resend"));
+        services.Configure<ResendClientOptions>(o =>
+        {
+            o.ApiToken = configuration["Resend:ApiKey"] ?? string.Empty;
+        });
+        services.AddOptions();
+        services.AddHttpClient<ResendClient>();
+        services.AddTransient<IResend, ResendClient>();
+        services.AddTransient<IEmailSender, ResendEmailSender>();
 
         return services;
     }

--- a/3 - Auth/Auth.Infrastructure/MyCRM.Auth.Infrastructure.csproj
+++ b/3 - Auth/Auth.Infrastructure/MyCRM.Auth.Infrastructure.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
@@ -16,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Resend" Version="0.3.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
   </ItemGroup>
 </Project>

--- a/3 - Auth/Auth.Infrastructure/Services/ResendEmailSender.cs
+++ b/3 - Auth/Auth.Infrastructure/Services/ResendEmailSender.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Resend;
+using ResendEmail = Resend.EmailMessage;
+using KernelEmail = MyCRM.Shared.Kernel.Services.EmailMessage;
+using MyCRM.Shared.Kernel.Services;
+
+namespace MyCRM.Auth.Infrastructure.Services;
+
+public sealed class ResendEmailSender : IEmailSender
+{
+    private readonly IResend _resend;
+    private readonly ResendSettings _settings;
+    private readonly ILogger<ResendEmailSender> _logger;
+
+    public ResendEmailSender(IResend resend, IOptions<ResendSettings> options, ILogger<ResendEmailSender> logger)
+    {
+        _resend   = resend;
+        _settings = options.Value;
+        _logger   = logger;
+    }
+
+    public async Task<EmailSendResult> SendAsync(KernelEmail message, CancellationToken ct = default)
+    {
+        try
+        {
+            var fromEmail = message.From ?? _settings.FromEmail;
+            var fromName  = message.FromName ?? _settings.FromName;
+            var fromAddress = string.IsNullOrWhiteSpace(fromName)
+                ? fromEmail
+                : $"{fromName} <{fromEmail}>";
+
+            var toAddress = string.IsNullOrWhiteSpace(message.ToName)
+                ? message.To
+                : $"{message.ToName} <{message.To}>";
+
+            var resendEmail = new ResendEmail
+            {
+                From     = fromAddress,
+                To       = { toAddress },
+                Subject  = message.Subject,
+                HtmlBody = message.HtmlBody,
+                TextBody = message.TextBody
+            };
+
+            await _resend.EmailSendAsync(resendEmail, ct);
+
+            return EmailSendResult.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Falha ao enviar email para {To}: {Error}", message.To, ex.Message);
+            return EmailSendResult.Failure("EMAIL_SEND_FAILED", ex.Message);
+        }
+    }
+}

--- a/3 - Auth/Auth.Infrastructure/Services/ResendSettings.cs
+++ b/3 - Auth/Auth.Infrastructure/Services/ResendSettings.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.Auth.Infrastructure.Services;
+
+public sealed class ResendSettings
+{
+    public string ApiKey { get; init; } = default!;
+    public string FromEmail { get; init; } = default!;
+    public string FromName { get; init; } = "Mundo da Lua CRM";
+}

--- a/3 - Shared/Shared.Kernel/Services/EmailMessage.cs
+++ b/3 - Shared/Shared.Kernel/Services/EmailMessage.cs
@@ -1,0 +1,10 @@
+namespace MyCRM.Shared.Kernel.Services;
+
+public sealed record EmailMessage(
+    string To,
+    string Subject,
+    string HtmlBody,
+    string? ToName = null,
+    string? TextBody = null,
+    string? From = null,
+    string? FromName = null);

--- a/3 - Shared/Shared.Kernel/Services/EmailSendResult.cs
+++ b/3 - Shared/Shared.Kernel/Services/EmailSendResult.cs
@@ -1,0 +1,7 @@
+namespace MyCRM.Shared.Kernel.Services;
+
+public sealed record EmailSendResult(bool IsSuccess, string? ErrorCode, string? ErrorMessage)
+{
+    public static EmailSendResult Success() => new(true, null, null);
+    public static EmailSendResult Failure(string errorCode, string errorMessage) => new(false, errorCode, errorMessage);
+}

--- a/3 - Shared/Shared.Kernel/Services/IEmailSender.cs
+++ b/3 - Shared/Shared.Kernel/Services/IEmailSender.cs
@@ -1,0 +1,6 @@
+namespace MyCRM.Shared.Kernel.Services;
+
+public interface IEmailSender
+{
+    Task<EmailSendResult> SendAsync(EmailMessage message, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary
- Adiciona contratos `IEmailSender`, `EmailMessage` e `EmailSendResult` em `Shared.Kernel` — agnóstico de provedor
- Implementa `ResendEmailSender` em `Auth.Infrastructure` usando o SDK oficial `Resend 0.3.0`
- Registra `IResend`, `ResendClient` e `IEmailSender` no DI container de `Auth.Infrastructure`
- Injeta `IEmailSender` em `RegisterTenantHandler` e envia email de boas-vindas após criação do tenant
- Falha no envio é apenas logada (`LogWarning`) — nunca propaga e não bloqueia o registro
- Adiciona seção `Resend` em `appsettings.json` com `ApiKey`, `FromEmail` e `FromName`

## Validação
- Build: `dotnet build` ✅ (0 erros)
- Testes: `dotnet test` ✅ (236 passando)
- Migration: não necessária (sem alteração de schema)

## Test plan
- [ ] Configurar `Resend:ApiKey` com chave válida do Resend dashboard
- [ ] Registrar novo tenant via mutation `registerTenant` e verificar recebimento do email de boas-vindas
- [ ] Testar com `ApiKey` inválida — registro deve completar com sucesso e log de warning deve aparecer
- [ ] Verificar que `IEmailSender` pode ser substituído por outra implementação sem alterar Application

🤖 Generated with [Claude Code](https://claude.com/claude-code)