### PR TITLE
fix(plans): GetActiveByTenantIdAsync inclui PendingCancellation

### DIFF
--- a/3 - Auth/Auth.Infrastructure/Repositories/TenantPlanRepository.cs
+++ b/3 - Auth/Auth.Infrastructure/Repositories/TenantPlanRepository.cs
@@ -15,7 +15,9 @@ public sealed class TenantPlanRepository : ITenantPlanRepository
     public async Task<TenantPlan?> GetActiveByTenantIdAsync(Guid tenantId, CancellationToken ct = default) =>
         await _db.TenantPlans
             .Include(x => x.Plan)
-            .FirstOrDefaultAsync(x => x.TenantId == tenantId && x.Status == TenantPlanStatus.Active, ct);
+            .FirstOrDefaultAsync(x => x.TenantId == tenantId
+                && (x.Status == TenantPlanStatus.Active
+                 || x.Status == TenantPlanStatus.PendingCancellation), ct);
 
     public async Task<TenantPlan?> GetPausedByTenantIdAsync(Guid tenantId, CancellationToken ct = default) =>
         await _db.TenantPlans


### PR DESCRIPTION
## Summary
- `GetActiveByTenantIdAsync` agora retorna planos com `Status = Active` **ou** `PendingCancellation`
- Corrige `revertCancellation` que retornava `TENANT_PLAN_NOT_FOUND` quando o plano estava em `PendingCancellation`
- Todos os handlers afetados já possuíam guards para o status `PendingCancellation` (sem regressão)

## Validação
- Build: dotnet build ✅
- Testes: dotnet test ✅ (297 passando, 0 falhas)

## Test plan
- [ ] `revertCancellation` funciona corretamente após cancelamento pendente
- [ ] `cancelTenantPlan` ainda rejeita plano já em `PendingCancellation` (`PLAN_NOT_ACTIVE`)
- [ ] `upgradeTenantPlan` ainda rejeita plano em `PendingCancellation` (`UPGRADE_BLOCKED_PENDING_CANCELLATION`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)