### PR TITLE
feat(agendamentos): entidades de domínio e repositórios — Lote 1

### DIFF
--- a/2 - CRM/CRM.Domain/Entities/Appointment.cs
+++ b/2 - CRM/CRM.Domain/Entities/Appointment.cs
@@ -1,0 +1,138 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Appointment : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public Guid PatientId { get; private set; }
+    public Guid ServiceId { get; private set; }
+    public DateTime StartDateTime { get; private set; }
+    public DateTime EndDateTime { get; private set; }
+    public AppointmentType Type { get; private set; }
+    public decimal Price { get; private set; }
+    public Address? Address { get; private set; }
+    public string? MeetingLink { get; private set; }
+    public PaymentReceiverType PaymentReceiver { get; private set; }
+    public Guid PaymentMethodId { get; private set; }
+    public AppointmentStatus Status { get; private set; }
+    public Guid? RecurrenceId { get; private set; }
+    public string? ConfirmedBy { get; private set; }
+    public DateTime? ConfirmedAt { get; private set; }
+    public string? CancellationReason { get; private set; }
+    public DateTime? CancelledAt { get; private set; }
+    public bool CancelledWithLateNotice { get; private set; }
+    public DateTime? NoShowAt { get; private set; }
+    public DateTime? CompletedAt { get; private set; }
+    public Guid? RescheduledFrom { get; private set; }
+    public DateTime? RescheduledAt { get; private set; }
+    public Guid? TransactionId { get; private set; }
+    public string? Notes { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public Patient? Patient { get; private set; }
+    public Service? Service { get; private set; }
+    public PaymentMethod? PaymentMethod { get; private set; }
+    public AppointmentRecurrence? Recurrence { get; private set; }
+
+    private Appointment() { }
+
+    public static Appointment Create(
+        Guid tenantId,
+        Guid professionalId,
+        Guid patientId,
+        Guid serviceId,
+        DateTime startDateTime,
+        DateTime endDateTime,
+        AppointmentType type,
+        decimal price,
+        PaymentReceiverType paymentReceiver,
+        Guid paymentMethodId,
+        Address? address = null,
+        string? meetingLink = null,
+        Guid? recurrenceId = null,
+        Guid? rescheduledFrom = null,
+        string? notes = null)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (patientId == Guid.Empty)
+            throw new ArgumentException("PatientId is required.", nameof(patientId));
+        if (serviceId == Guid.Empty)
+            throw new ArgumentException("ServiceId is required.", nameof(serviceId));
+        if (paymentMethodId == Guid.Empty)
+            throw new ArgumentException("PaymentMethodId is required.", nameof(paymentMethodId));
+        if (price <= 0)
+            throw new ArgumentException("Price must be greater than zero.", nameof(price));
+        if (endDateTime <= startDateTime)
+            throw new ArgumentException("EndDateTime must be greater than StartDateTime.", nameof(endDateTime));
+
+        return new Appointment
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            PatientId = patientId,
+            ServiceId = serviceId,
+            StartDateTime = startDateTime,
+            EndDateTime = endDateTime,
+            Type = type,
+            Price = price,
+            Address = address,
+            MeetingLink = meetingLink?.Trim(),
+            PaymentReceiver = paymentReceiver,
+            PaymentMethodId = paymentMethodId,
+            Status = AppointmentStatus.Suggested,
+            RecurrenceId = recurrenceId,
+            RescheduledFrom = rescheduledFrom,
+            RescheduledAt = rescheduledFrom.HasValue ? DateTime.UtcNow : null,
+            Notes = notes?.Trim()
+        };
+    }
+
+    public void Confirm(string confirmedBy)
+    {
+        Status = AppointmentStatus.Confirmed;
+        ConfirmedBy = confirmedBy?.Trim();
+        ConfirmedAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void Complete(Guid? transactionId = null)
+    {
+        Status = AppointmentStatus.Completed;
+        CompletedAt = DateTime.UtcNow;
+        TransactionId = transactionId;
+        Touch();
+    }
+
+    public void Cancel(string? reason, bool lateNotice = false)
+    {
+        Status = AppointmentStatus.Cancelled;
+        CancellationReason = reason?.Trim();
+        CancelledAt = DateTime.UtcNow;
+        CancelledWithLateNotice = lateNotice;
+        Touch();
+    }
+
+    public void MarkNoShow()
+    {
+        Status = AppointmentStatus.NoShow;
+        NoShowAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void MarkRescheduled()
+    {
+        Status = AppointmentStatus.Rescheduled;
+        Touch();
+    }
+
+    public void LinkTransaction(Guid transactionId)
+    {
+        TransactionId = transactionId;
+        Touch();
+    }
+
+    public void UpdateNotes(string? notes) { Notes = notes?.Trim(); Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentRecurrence.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentRecurrence.cs
@@ -1,0 +1,34 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class AppointmentRecurrence : TenantEntity
+{
+    public RecurrenceFrequency Frequency { get; private set; }
+    public DateOnly? EndDate { get; private set; }
+    public int? MaxOccurrences { get; private set; }
+    public Guid ParentAppointmentId { get; private set; }
+    public int CreatedOccurrences { get; private set; }
+
+    private AppointmentRecurrence() { }
+
+    public static AppointmentRecurrence Create(Guid tenantId, Guid parentAppointmentId, RecurrenceFrequency frequency, DateOnly? endDate = null, int? maxOccurrences = null)
+    {
+        if (parentAppointmentId == Guid.Empty)
+            throw new ArgumentException("ParentAppointmentId is required.", nameof(parentAppointmentId));
+        if (endDate == null && maxOccurrences == null)
+            throw new ArgumentException("Either EndDate or MaxOccurrences must be provided (RN-057).");
+
+        return new AppointmentRecurrence
+        {
+            TenantId = tenantId,
+            ParentAppointmentId = parentAppointmentId,
+            Frequency = frequency,
+            EndDate = endDate,
+            MaxOccurrences = maxOccurrences,
+            CreatedOccurrences = 0
+        };
+    }
+
+    public void IncrementOccurrences() { CreatedOccurrences++; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentStatus.cs
@@ -1,0 +1,11 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentStatus
+{
+    Suggested = 1,
+    Confirmed = 2,
+    Rescheduled = 3,
+    Completed = 4,
+    Cancelled = 5,
+    NoShow = 6
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentTask.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentTask.cs
@@ -1,0 +1,57 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class AppointmentTask : TenantEntity
+{
+    public Guid AppointmentId { get; private set; }
+    public AppointmentTaskType Type { get; private set; }
+    public Guid? AssignedToUserId { get; private set; }
+    public string? AssignedToRole { get; private set; }
+    public AppointmentTaskStatus Status { get; private set; }
+    public string? Result { get; private set; }
+    public DateTime? ResolvedAt { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Appointment? Appointment { get; private set; }
+
+    private AppointmentTask() { }
+
+    public static AppointmentTask Create(Guid tenantId, Guid appointmentId, AppointmentTaskType type, Guid? assignedToUserId = null, string? assignedToRole = null)
+    {
+        if (appointmentId == Guid.Empty)
+            throw new ArgumentException("AppointmentId is required.", nameof(appointmentId));
+
+        return new AppointmentTask
+        {
+            TenantId = tenantId,
+            AppointmentId = appointmentId,
+            Type = type,
+            AssignedToUserId = assignedToUserId,
+            AssignedToRole = assignedToRole?.Trim(),
+            Status = AppointmentTaskStatus.Pending
+        };
+    }
+
+    public void Complete(string? result)
+    {
+        Status = AppointmentTaskStatus.Completed;
+        Result = result?.Trim();
+        ResolvedAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void Escalate()
+    {
+        Status = AppointmentTaskStatus.Escalated;
+        ResolvedAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void Expire()
+    {
+        Status = AppointmentTaskStatus.Expired;
+        ResolvedAt = DateTime.UtcNow;
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentTaskStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentTaskStatus.cs
@@ -1,0 +1,9 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentTaskStatus
+{
+    Pending = 1,
+    Completed = 2,
+    Escalated = 3,
+    Expired = 4
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentTaskType.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentTaskType.cs
@@ -1,0 +1,7 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentTaskType
+{
+    NoShowDecision = 1,
+    Escalation = 2
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentType.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentType.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentType
+{
+    Presencial = 1,
+    Remoto = 2,
+    Domicilio = 3
+}

--- a/2 - CRM/CRM.Domain/Entities/CommissionRule.cs
+++ b/2 - CRM/CRM.Domain/Entities/CommissionRule.cs
@@ -1,0 +1,39 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class CommissionRule : TenantEntity
+{
+    public Guid? ProfessionalId { get; private set; }
+    public Guid? ServiceId { get; private set; }
+    public decimal CompanyPercentage { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public Service? Service { get; private set; }
+
+    private CommissionRule() { }
+
+    public static CommissionRule Create(Guid tenantId, decimal companyPercentage, Guid? professionalId = null, Guid? serviceId = null)
+    {
+        if (companyPercentage < 0 || companyPercentage > 100)
+            throw new ArgumentException("CompanyPercentage must be between 0 and 100.", nameof(companyPercentage));
+
+        return new CommissionRule
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            ServiceId = serviceId,
+            CompanyPercentage = companyPercentage
+        };
+    }
+
+    public void Update(decimal companyPercentage)
+    {
+        if (companyPercentage < 0 || companyPercentage > 100)
+            throw new ArgumentException("CompanyPercentage must be between 0 and 100.", nameof(companyPercentage));
+
+        CompanyPercentage = companyPercentage;
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/Patient.cs
+++ b/2 - CRM/CRM.Domain/Entities/Patient.cs
@@ -1,0 +1,34 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Patient : TenantEntity
+{
+    public Guid PersonId { get; private set; }
+    public PatientStatus Status { get; private set; }
+    public string? Notes { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Person? Person { get; private set; }
+
+    private Patient() { }
+
+    public static Patient Create(Guid tenantId, Guid personId, string? notes = null)
+    {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
+        return new Patient
+        {
+            TenantId = tenantId,
+            PersonId = personId,
+            Status = PatientStatus.Active,
+            Notes = notes?.Trim()
+        };
+    }
+
+    public void UpdateNotes(string? notes) { Notes = notes?.Trim(); Touch(); }
+    public void Activate() { Status = PatientStatus.Active; Touch(); }
+    public void Deactivate() { Status = PatientStatus.Inactive; Touch(); }
+    public void Block() { Status = PatientStatus.Blocked; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/PatientStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/PatientStatus.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum PatientStatus
+{
+    Active = 1,
+    Inactive = 2,
+    Blocked = 3
+}

--- a/2 - CRM/CRM.Domain/Entities/PaymentMethod.cs
+++ b/2 - CRM/CRM.Domain/Entities/PaymentMethod.cs
@@ -5,6 +5,10 @@ namespace MyCRM.CRM.Domain.Entities;
 public sealed class PaymentMethod : TenantEntity
 {
     public string Name { get; private set; } = string.Empty;
+    public Guid? WalletId { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Wallet? Wallet { get; private set; }
 
     private PaymentMethod() { }
 

--- a/2 - CRM/CRM.Domain/Entities/PaymentReceiverType.cs
+++ b/2 - CRM/CRM.Domain/Entities/PaymentReceiverType.cs
@@ -1,0 +1,7 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum PaymentReceiverType
+{
+    Company = 1,
+    Professional = 2
+}

--- a/2 - CRM/CRM.Domain/Entities/Professional.cs
+++ b/2 - CRM/CRM.Domain/Entities/Professional.cs
@@ -1,0 +1,57 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Professional : TenantEntity
+{
+    public Guid PersonId { get; private set; }
+    public decimal? CommissionPercentage { get; private set; }
+    public ProfessionalStatus Status { get; private set; }
+    public string? Bio { get; private set; }
+    public string? LicenseNumber { get; private set; }
+    public Guid? WalletId { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Person? Person { get; private set; }
+    public Wallet? Wallet { get; private set; }
+
+    private Professional() { }
+
+    public static Professional Create(Guid tenantId, Guid personId, string? bio = null, string? licenseNumber = null, decimal? commissionPercentage = null)
+    {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
+        return new Professional
+        {
+            TenantId = tenantId,
+            PersonId = personId,
+            Status = ProfessionalStatus.Draft,
+            Bio = bio?.Trim(),
+            LicenseNumber = licenseNumber?.Trim(),
+            CommissionPercentage = commissionPercentage
+        };
+    }
+
+    public void Update(string? bio, string? licenseNumber, decimal? commissionPercentage)
+    {
+        Bio = bio?.Trim();
+        LicenseNumber = licenseNumber?.Trim();
+        CommissionPercentage = commissionPercentage;
+        Touch();
+    }
+
+    // Wallet criada automaticamente ao ativar Draft → Active (RN-061)
+    public void Activate(Guid walletId)
+    {
+        if (walletId == Guid.Empty)
+            throw new ArgumentException("WalletId is required to activate a Professional (RN-061).", nameof(walletId));
+        Status = ProfessionalStatus.Active;
+        WalletId = walletId;
+        Touch();
+    }
+
+    public void Deactivate() { Status = ProfessionalStatus.Inactive; Touch(); }
+    public void Suspend() { Status = ProfessionalStatus.Suspended; Touch(); }
+    public void Terminate() { Status = ProfessionalStatus.Terminated; SoftDelete(); Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalSchedule.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalSchedule.cs
@@ -1,0 +1,48 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalSchedule : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public int DayOfWeek { get; private set; }
+    public TimeSpan StartTime { get; private set; }
+    public TimeSpan EndTime { get; private set; }
+    public bool IsAvailable { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+
+    private ProfessionalSchedule() { }
+
+    public static ProfessionalSchedule Create(Guid tenantId, Guid professionalId, int dayOfWeek, TimeSpan startTime, TimeSpan endTime, bool isAvailable = true)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (dayOfWeek < 0 || dayOfWeek > 6)
+            throw new ArgumentException("DayOfWeek must be between 0 (Sunday) and 6 (Saturday).", nameof(dayOfWeek));
+        if (endTime <= startTime)
+            throw new ArgumentException("EndTime must be greater than StartTime.", nameof(endTime));
+
+        return new ProfessionalSchedule
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            DayOfWeek = dayOfWeek,
+            StartTime = startTime,
+            EndTime = endTime,
+            IsAvailable = isAvailable
+        };
+    }
+
+    public void Update(TimeSpan startTime, TimeSpan endTime, bool isAvailable)
+    {
+        if (endTime <= startTime)
+            throw new ArgumentException("EndTime must be greater than StartTime.", nameof(endTime));
+
+        StartTime = startTime;
+        EndTime = endTime;
+        IsAvailable = isAvailable;
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalService.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalService.cs
@@ -1,0 +1,55 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalService : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public Guid ServiceId { get; private set; }
+    public decimal? CustomPrice { get; private set; }
+    public int? CustomDurationInMinutes { get; private set; }
+    public bool IsActive { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public Service? Service { get; private set; }
+
+    private ProfessionalService() { }
+
+    public static ProfessionalService Create(Guid tenantId, Guid professionalId, Guid serviceId, decimal? customPrice = null, int? customDurationInMinutes = null)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (serviceId == Guid.Empty)
+            throw new ArgumentException("ServiceId is required.", nameof(serviceId));
+        if (customPrice.HasValue && customPrice <= 0)
+            throw new ArgumentException("CustomPrice must be greater than zero.", nameof(customPrice));
+        if (customDurationInMinutes.HasValue && customDurationInMinutes <= 0)
+            throw new ArgumentException("CustomDurationInMinutes must be greater than zero.", nameof(customDurationInMinutes));
+
+        return new ProfessionalService
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            ServiceId = serviceId,
+            CustomPrice = customPrice,
+            CustomDurationInMinutes = customDurationInMinutes,
+            IsActive = true
+        };
+    }
+
+    public void Update(decimal? customPrice, int? customDurationInMinutes)
+    {
+        if (customPrice.HasValue && customPrice <= 0)
+            throw new ArgumentException("CustomPrice must be greater than zero.", nameof(customPrice));
+        if (customDurationInMinutes.HasValue && customDurationInMinutes <= 0)
+            throw new ArgumentException("CustomDurationInMinutes must be greater than zero.", nameof(customDurationInMinutes));
+
+        CustomPrice = customPrice;
+        CustomDurationInMinutes = customDurationInMinutes;
+        Touch();
+    }
+
+    public void Activate() { IsActive = true; Touch(); }
+    public void Deactivate() { IsActive = false; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialty.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialty.cs
@@ -1,0 +1,34 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalSpecialty : TenantEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+
+    private ProfessionalSpecialty() { }
+
+    public static ProfessionalSpecialty Create(Guid tenantId, string name, string? description = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Specialty name is required.", nameof(name));
+
+        return new ProfessionalSpecialty
+        {
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description?.Trim()
+        };
+    }
+
+    public void Update(string name, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Specialty name is required.", nameof(name));
+
+        Name = name.Trim();
+        Description = description?.Trim();
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialtyLink.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialtyLink.cs
@@ -1,0 +1,30 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalSpecialtyLink : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public Guid SpecialtyId { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public ProfessionalSpecialty? Specialty { get; private set; }
+
+    private ProfessionalSpecialtyLink() { }
+
+    public static ProfessionalSpecialtyLink Create(Guid tenantId, Guid professionalId, Guid specialtyId)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (specialtyId == Guid.Empty)
+            throw new ArgumentException("SpecialtyId is required.", nameof(specialtyId));
+
+        return new ProfessionalSpecialtyLink
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            SpecialtyId = specialtyId
+        };
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalStatus.cs
@@ -1,0 +1,10 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum ProfessionalStatus
+{
+    Draft = 0,
+    Active = 1,
+    Inactive = 2,
+    Suspended = 3,
+    Terminated = 4
+}

--- a/2 - CRM/CRM.Domain/Entities/RecurrenceFrequency.cs
+++ b/2 - CRM/CRM.Domain/Entities/RecurrenceFrequency.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum RecurrenceFrequency
+{
+    Weekly = 1,
+    Biweekly = 2,
+    Monthly = 3
+}

--- a/2 - CRM/CRM.Domain/Entities/Service.cs
+++ b/2 - CRM/CRM.Domain/Entities/Service.cs
@@ -1,0 +1,53 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Service : TenantEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+    public decimal DefaultPrice { get; private set; }
+    public int DefaultDurationInMinutes { get; private set; }
+    public bool IsActive { get; private set; }
+
+    private Service() { }
+
+    public static Service Create(Guid tenantId, string name, decimal defaultPrice, int defaultDurationInMinutes, string? description = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Service name is required.", nameof(name));
+        if (defaultPrice <= 0)
+            throw new ArgumentException("DefaultPrice must be greater than zero.", nameof(defaultPrice));
+        if (defaultDurationInMinutes <= 0)
+            throw new ArgumentException("DefaultDurationInMinutes must be greater than zero.", nameof(defaultDurationInMinutes));
+
+        return new Service
+        {
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description?.Trim(),
+            DefaultPrice = defaultPrice,
+            DefaultDurationInMinutes = defaultDurationInMinutes,
+            IsActive = true
+        };
+    }
+
+    public void Update(string name, decimal defaultPrice, int defaultDurationInMinutes, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Service name is required.", nameof(name));
+        if (defaultPrice <= 0)
+            throw new ArgumentException("DefaultPrice must be greater than zero.", nameof(defaultPrice));
+        if (defaultDurationInMinutes <= 0)
+            throw new ArgumentException("DefaultDurationInMinutes must be greater than zero.", nameof(defaultDurationInMinutes));
+
+        Name = name.Trim();
+        Description = description?.Trim();
+        DefaultPrice = defaultPrice;
+        DefaultDurationInMinutes = defaultDurationInMinutes;
+        Touch();
+    }
+
+    public void Activate() { IsActive = true; Touch(); }
+    public void Deactivate() { IsActive = false; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Repositories/IAppointmentRecurrenceRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IAppointmentRecurrenceRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IAppointmentRecurrenceRepository : IRepository<AppointmentRecurrence>
+{
+    Task<IReadOnlyList<AppointmentRecurrence>> GetActiveByParentAsync(Guid parentAppointmentId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IAppointmentRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IAppointmentRepository.cs
@@ -1,0 +1,11 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IAppointmentRepository : IRepository<Appointment>
+{
+    Task<bool> HasConflictAsync(Guid professionalId, DateTime startDateTime, DateTime endDateTime, Guid? excludeId = null, CancellationToken ct = default);
+    Task<IReadOnlyList<Appointment>> GetByProfessionalAsync(Guid tenantId, Guid professionalId, DateOnly date, CancellationToken ct = default);
+    Task<IReadOnlyList<Appointment>> GetByPatientAsync(Guid tenantId, Guid patientId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IAppointmentTaskRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IAppointmentTaskRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IAppointmentTaskRepository : IRepository<AppointmentTask>
+{
+    Task<IReadOnlyList<AppointmentTask>> GetPendingByAppointmentAsync(Guid appointmentId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/ICommissionRuleRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/ICommissionRuleRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface ICommissionRuleRepository : IRepository<CommissionRule>
+{
+    Task<CommissionRule?> GetEffectiveRuleAsync(Guid tenantId, Guid professionalId, Guid serviceId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IPatientRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IPatientRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IPatientRepository : IRepository<Patient>
+{
+    Task<bool> PersonAlreadyActivePatientAsync(Guid tenantId, Guid personId, Guid? excludeId = null, CancellationToken ct = default);
+    Task<Patient?> GetByPersonIdAsync(Guid tenantId, Guid personId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalRepository : IRepository<Professional>
+{
+    Task<bool> PersonAlreadyActiveProfessionalAsync(Guid tenantId, Guid personId, Guid? excludeId = null, CancellationToken ct = default);
+    Task<Professional?> GetByPersonIdAsync(Guid tenantId, Guid personId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalScheduleRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalScheduleRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalScheduleRepository : IRepository<ProfessionalSchedule>
+{
+    Task<bool> DayAlreadyScheduledAsync(Guid professionalId, int dayOfWeek, Guid? excludeId = null, CancellationToken ct = default);
+    Task<IReadOnlyList<ProfessionalSchedule>> GetByProfessionalAsync(Guid professionalId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalServiceRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalServiceRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalServiceRepository : IRepository<ProfessionalService>
+{
+    Task<bool> LinkExistsAsync(Guid professionalId, Guid serviceId, Guid? excludeId = null, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyLinkRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyLinkRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalSpecialtyLinkRepository : IRepository<ProfessionalSpecialtyLink>
+{
+    Task<bool> LinkExistsAsync(Guid professionalId, Guid specialtyId, CancellationToken ct = default);
+    Task<int> CountByProfessionalAsync(Guid professionalId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalSpecialtyRepository : IRepository<ProfessionalSpecialty>
+{
+    Task<bool> NameExistsAsync(Guid tenantId, string name, Guid? excludeId = null, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IServiceRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IServiceRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IServiceRepository : IRepository<Service>
+{
+    Task<bool> NameExistsAsync(Guid tenantId, string name, Guid? excludeId = null, CancellationToken ct = default);
+}


### PR DESCRIPTION
## Summary
- 8 enums criados: ProfessionalStatus, PatientStatus, AppointmentType/Status, PaymentReceiverType, RecurrenceFrequency, AppointmentTaskType/Status
- 11 entidades criadas: Professional, Patient, Service, ProfessionalSpecialty/Link, ProfessionalService, CommissionRule, ProfessionalSchedule, Appointment, AppointmentRecurrence, AppointmentTask
- 11 interfaces de repositório criadas em `CRM.Domain/Repositories/`
- `PaymentMethod` modificado: `WalletId (Guid?)` + navegação `Wallet?` adicionados

## Test plan
- [ ] `dotnet build MyCRM.sln` — zero erros ✅ (verificado localmente)
- [ ] Sem testes unitários neste lote (apenas estrutura de domínio, conforme spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)