### PR TITLE
feat(agendamentos): infraestrutura — DbContext, configurations, repos e migration — Lote 2

### DIFF
--- a/2 - CRM/CRM.Domain/Entities/Appointment.cs
+++ b/2 - CRM/CRM.Domain/Entities/Appointment.cs
@@ -1,0 +1,138 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Appointment : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public Guid PatientId { get; private set; }
+    public Guid ServiceId { get; private set; }
+    public DateTime StartDateTime { get; private set; }
+    public DateTime EndDateTime { get; private set; }
+    public AppointmentType Type { get; private set; }
+    public decimal Price { get; private set; }
+    public Address? Address { get; private set; }
+    public string? MeetingLink { get; private set; }
+    public PaymentReceiverType PaymentReceiver { get; private set; }
+    public Guid PaymentMethodId { get; private set; }
+    public AppointmentStatus Status { get; private set; }
+    public Guid? RecurrenceId { get; private set; }
+    public string? ConfirmedBy { get; private set; }
+    public DateTime? ConfirmedAt { get; private set; }
+    public string? CancellationReason { get; private set; }
+    public DateTime? CancelledAt { get; private set; }
+    public bool CancelledWithLateNotice { get; private set; }
+    public DateTime? NoShowAt { get; private set; }
+    public DateTime? CompletedAt { get; private set; }
+    public Guid? RescheduledFrom { get; private set; }
+    public DateTime? RescheduledAt { get; private set; }
+    public Guid? TransactionId { get; private set; }
+    public string? Notes { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public Patient? Patient { get; private set; }
+    public Service? Service { get; private set; }
+    public PaymentMethod? PaymentMethod { get; private set; }
+    public AppointmentRecurrence? Recurrence { get; private set; }
+
+    private Appointment() { }
+
+    public static Appointment Create(
+        Guid tenantId,
+        Guid professionalId,
+        Guid patientId,
+        Guid serviceId,
+        DateTime startDateTime,
+        DateTime endDateTime,
+        AppointmentType type,
+        decimal price,
+        PaymentReceiverType paymentReceiver,
+        Guid paymentMethodId,
+        Address? address = null,
+        string? meetingLink = null,
+        Guid? recurrenceId = null,
+        Guid? rescheduledFrom = null,
+        string? notes = null)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (patientId == Guid.Empty)
+            throw new ArgumentException("PatientId is required.", nameof(patientId));
+        if (serviceId == Guid.Empty)
+            throw new ArgumentException("ServiceId is required.", nameof(serviceId));
+        if (paymentMethodId == Guid.Empty)
+            throw new ArgumentException("PaymentMethodId is required.", nameof(paymentMethodId));
+        if (price <= 0)
+            throw new ArgumentException("Price must be greater than zero.", nameof(price));
+        if (endDateTime <= startDateTime)
+            throw new ArgumentException("EndDateTime must be greater than StartDateTime.", nameof(endDateTime));
+
+        return new Appointment
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            PatientId = patientId,
+            ServiceId = serviceId,
+            StartDateTime = startDateTime,
+            EndDateTime = endDateTime,
+            Type = type,
+            Price = price,
+            Address = address,
+            MeetingLink = meetingLink?.Trim(),
+            PaymentReceiver = paymentReceiver,
+            PaymentMethodId = paymentMethodId,
+            Status = AppointmentStatus.Suggested,
+            RecurrenceId = recurrenceId,
+            RescheduledFrom = rescheduledFrom,
+            RescheduledAt = rescheduledFrom.HasValue ? DateTime.UtcNow : null,
+            Notes = notes?.Trim()
+        };
+    }
+
+    public void Confirm(string confirmedBy)
+    {
+        Status = AppointmentStatus.Confirmed;
+        ConfirmedBy = confirmedBy?.Trim();
+        ConfirmedAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void Complete(Guid? transactionId = null)
+    {
+        Status = AppointmentStatus.Completed;
+        CompletedAt = DateTime.UtcNow;
+        TransactionId = transactionId;
+        Touch();
+    }
+
+    public void Cancel(string? reason, bool lateNotice = false)
+    {
+        Status = AppointmentStatus.Cancelled;
+        CancellationReason = reason?.Trim();
+        CancelledAt = DateTime.UtcNow;
+        CancelledWithLateNotice = lateNotice;
+        Touch();
+    }
+
+    public void MarkNoShow()
+    {
+        Status = AppointmentStatus.NoShow;
+        NoShowAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void MarkRescheduled()
+    {
+        Status = AppointmentStatus.Rescheduled;
+        Touch();
+    }
+
+    public void LinkTransaction(Guid transactionId)
+    {
+        TransactionId = transactionId;
+        Touch();
+    }
+
+    public void UpdateNotes(string? notes) { Notes = notes?.Trim(); Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentRecurrence.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentRecurrence.cs
@@ -1,0 +1,34 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class AppointmentRecurrence : TenantEntity
+{
+    public RecurrenceFrequency Frequency { get; private set; }
+    public DateOnly? EndDate { get; private set; }
+    public int? MaxOccurrences { get; private set; }
+    public Guid ParentAppointmentId { get; private set; }
+    public int CreatedOccurrences { get; private set; }
+
+    private AppointmentRecurrence() { }
+
+    public static AppointmentRecurrence Create(Guid tenantId, Guid parentAppointmentId, RecurrenceFrequency frequency, DateOnly? endDate = null, int? maxOccurrences = null)
+    {
+        if (parentAppointmentId == Guid.Empty)
+            throw new ArgumentException("ParentAppointmentId is required.", nameof(parentAppointmentId));
+        if (endDate == null && maxOccurrences == null)
+            throw new ArgumentException("Either EndDate or MaxOccurrences must be provided (RN-057).");
+
+        return new AppointmentRecurrence
+        {
+            TenantId = tenantId,
+            ParentAppointmentId = parentAppointmentId,
+            Frequency = frequency,
+            EndDate = endDate,
+            MaxOccurrences = maxOccurrences,
+            CreatedOccurrences = 0
+        };
+    }
+
+    public void IncrementOccurrences() { CreatedOccurrences++; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentStatus.cs
@@ -1,0 +1,11 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentStatus
+{
+    Suggested = 1,
+    Confirmed = 2,
+    Rescheduled = 3,
+    Completed = 4,
+    Cancelled = 5,
+    NoShow = 6
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentTask.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentTask.cs
@@ -1,0 +1,57 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class AppointmentTask : TenantEntity
+{
+    public Guid AppointmentId { get; private set; }
+    public AppointmentTaskType Type { get; private set; }
+    public Guid? AssignedToUserId { get; private set; }
+    public string? AssignedToRole { get; private set; }
+    public AppointmentTaskStatus Status { get; private set; }
+    public string? Result { get; private set; }
+    public DateTime? ResolvedAt { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Appointment? Appointment { get; private set; }
+
+    private AppointmentTask() { }
+
+    public static AppointmentTask Create(Guid tenantId, Guid appointmentId, AppointmentTaskType type, Guid? assignedToUserId = null, string? assignedToRole = null)
+    {
+        if (appointmentId == Guid.Empty)
+            throw new ArgumentException("AppointmentId is required.", nameof(appointmentId));
+
+        return new AppointmentTask
+        {
+            TenantId = tenantId,
+            AppointmentId = appointmentId,
+            Type = type,
+            AssignedToUserId = assignedToUserId,
+            AssignedToRole = assignedToRole?.Trim(),
+            Status = AppointmentTaskStatus.Pending
+        };
+    }
+
+    public void Complete(string? result)
+    {
+        Status = AppointmentTaskStatus.Completed;
+        Result = result?.Trim();
+        ResolvedAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void Escalate()
+    {
+        Status = AppointmentTaskStatus.Escalated;
+        ResolvedAt = DateTime.UtcNow;
+        Touch();
+    }
+
+    public void Expire()
+    {
+        Status = AppointmentTaskStatus.Expired;
+        ResolvedAt = DateTime.UtcNow;
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentTaskStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentTaskStatus.cs
@@ -1,0 +1,9 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentTaskStatus
+{
+    Pending = 1,
+    Completed = 2,
+    Escalated = 3,
+    Expired = 4
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentTaskType.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentTaskType.cs
@@ -1,0 +1,7 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentTaskType
+{
+    NoShowDecision = 1,
+    Escalation = 2
+}

--- a/2 - CRM/CRM.Domain/Entities/AppointmentType.cs
+++ b/2 - CRM/CRM.Domain/Entities/AppointmentType.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum AppointmentType
+{
+    Presencial = 1,
+    Remoto = 2,
+    Domicilio = 3
+}

--- a/2 - CRM/CRM.Domain/Entities/CommissionRule.cs
+++ b/2 - CRM/CRM.Domain/Entities/CommissionRule.cs
@@ -1,0 +1,39 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class CommissionRule : TenantEntity
+{
+    public Guid? ProfessionalId { get; private set; }
+    public Guid? ServiceId { get; private set; }
+    public decimal CompanyPercentage { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public Service? Service { get; private set; }
+
+    private CommissionRule() { }
+
+    public static CommissionRule Create(Guid tenantId, decimal companyPercentage, Guid? professionalId = null, Guid? serviceId = null)
+    {
+        if (companyPercentage < 0 || companyPercentage > 100)
+            throw new ArgumentException("CompanyPercentage must be between 0 and 100.", nameof(companyPercentage));
+
+        return new CommissionRule
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            ServiceId = serviceId,
+            CompanyPercentage = companyPercentage
+        };
+    }
+
+    public void Update(decimal companyPercentage)
+    {
+        if (companyPercentage < 0 || companyPercentage > 100)
+            throw new ArgumentException("CompanyPercentage must be between 0 and 100.", nameof(companyPercentage));
+
+        CompanyPercentage = companyPercentage;
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/Patient.cs
+++ b/2 - CRM/CRM.Domain/Entities/Patient.cs
@@ -1,0 +1,34 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Patient : TenantEntity
+{
+    public Guid PersonId { get; private set; }
+    public PatientStatus Status { get; private set; }
+    public string? Notes { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Person? Person { get; private set; }
+
+    private Patient() { }
+
+    public static Patient Create(Guid tenantId, Guid personId, string? notes = null)
+    {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
+        return new Patient
+        {
+            TenantId = tenantId,
+            PersonId = personId,
+            Status = PatientStatus.Active,
+            Notes = notes?.Trim()
+        };
+    }
+
+    public void UpdateNotes(string? notes) { Notes = notes?.Trim(); Touch(); }
+    public void Activate() { Status = PatientStatus.Active; Touch(); }
+    public void Deactivate() { Status = PatientStatus.Inactive; Touch(); }
+    public void Block() { Status = PatientStatus.Blocked; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/PatientStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/PatientStatus.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum PatientStatus
+{
+    Active = 1,
+    Inactive = 2,
+    Blocked = 3
+}

--- a/2 - CRM/CRM.Domain/Entities/PaymentMethod.cs
+++ b/2 - CRM/CRM.Domain/Entities/PaymentMethod.cs
@@ -5,6 +5,10 @@ namespace MyCRM.CRM.Domain.Entities;
 public sealed class PaymentMethod : TenantEntity
 {
     public string Name { get; private set; } = string.Empty;
+    public Guid? WalletId { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Wallet? Wallet { get; private set; }
 
     private PaymentMethod() { }
 

--- a/2 - CRM/CRM.Domain/Entities/PaymentReceiverType.cs
+++ b/2 - CRM/CRM.Domain/Entities/PaymentReceiverType.cs
@@ -1,0 +1,7 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum PaymentReceiverType
+{
+    Company = 1,
+    Professional = 2
+}

--- a/2 - CRM/CRM.Domain/Entities/Professional.cs
+++ b/2 - CRM/CRM.Domain/Entities/Professional.cs
@@ -1,0 +1,57 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Professional : TenantEntity
+{
+    public Guid PersonId { get; private set; }
+    public decimal? CommissionPercentage { get; private set; }
+    public ProfessionalStatus Status { get; private set; }
+    public string? Bio { get; private set; }
+    public string? LicenseNumber { get; private set; }
+    public Guid? WalletId { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Person? Person { get; private set; }
+    public Wallet? Wallet { get; private set; }
+
+    private Professional() { }
+
+    public static Professional Create(Guid tenantId, Guid personId, string? bio = null, string? licenseNumber = null, decimal? commissionPercentage = null)
+    {
+        if (personId == Guid.Empty)
+            throw new ArgumentException("PersonId is required.", nameof(personId));
+
+        return new Professional
+        {
+            TenantId = tenantId,
+            PersonId = personId,
+            Status = ProfessionalStatus.Draft,
+            Bio = bio?.Trim(),
+            LicenseNumber = licenseNumber?.Trim(),
+            CommissionPercentage = commissionPercentage
+        };
+    }
+
+    public void Update(string? bio, string? licenseNumber, decimal? commissionPercentage)
+    {
+        Bio = bio?.Trim();
+        LicenseNumber = licenseNumber?.Trim();
+        CommissionPercentage = commissionPercentage;
+        Touch();
+    }
+
+    // Wallet criada automaticamente ao ativar Draft → Active (RN-061)
+    public void Activate(Guid walletId)
+    {
+        if (walletId == Guid.Empty)
+            throw new ArgumentException("WalletId is required to activate a Professional (RN-061).", nameof(walletId));
+        Status = ProfessionalStatus.Active;
+        WalletId = walletId;
+        Touch();
+    }
+
+    public void Deactivate() { Status = ProfessionalStatus.Inactive; Touch(); }
+    public void Suspend() { Status = ProfessionalStatus.Suspended; Touch(); }
+    public void Terminate() { Status = ProfessionalStatus.Terminated; SoftDelete(); Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalSchedule.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalSchedule.cs
@@ -1,0 +1,48 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalSchedule : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public int DayOfWeek { get; private set; }
+    public TimeSpan StartTime { get; private set; }
+    public TimeSpan EndTime { get; private set; }
+    public bool IsAvailable { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+
+    private ProfessionalSchedule() { }
+
+    public static ProfessionalSchedule Create(Guid tenantId, Guid professionalId, int dayOfWeek, TimeSpan startTime, TimeSpan endTime, bool isAvailable = true)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (dayOfWeek < 0 || dayOfWeek > 6)
+            throw new ArgumentException("DayOfWeek must be between 0 (Sunday) and 6 (Saturday).", nameof(dayOfWeek));
+        if (endTime <= startTime)
+            throw new ArgumentException("EndTime must be greater than StartTime.", nameof(endTime));
+
+        return new ProfessionalSchedule
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            DayOfWeek = dayOfWeek,
+            StartTime = startTime,
+            EndTime = endTime,
+            IsAvailable = isAvailable
+        };
+    }
+
+    public void Update(TimeSpan startTime, TimeSpan endTime, bool isAvailable)
+    {
+        if (endTime <= startTime)
+            throw new ArgumentException("EndTime must be greater than StartTime.", nameof(endTime));
+
+        StartTime = startTime;
+        EndTime = endTime;
+        IsAvailable = isAvailable;
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalService.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalService.cs
@@ -1,0 +1,55 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalService : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public Guid ServiceId { get; private set; }
+    public decimal? CustomPrice { get; private set; }
+    public int? CustomDurationInMinutes { get; private set; }
+    public bool IsActive { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public Service? Service { get; private set; }
+
+    private ProfessionalService() { }
+
+    public static ProfessionalService Create(Guid tenantId, Guid professionalId, Guid serviceId, decimal? customPrice = null, int? customDurationInMinutes = null)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (serviceId == Guid.Empty)
+            throw new ArgumentException("ServiceId is required.", nameof(serviceId));
+        if (customPrice.HasValue && customPrice <= 0)
+            throw new ArgumentException("CustomPrice must be greater than zero.", nameof(customPrice));
+        if (customDurationInMinutes.HasValue && customDurationInMinutes <= 0)
+            throw new ArgumentException("CustomDurationInMinutes must be greater than zero.", nameof(customDurationInMinutes));
+
+        return new ProfessionalService
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            ServiceId = serviceId,
+            CustomPrice = customPrice,
+            CustomDurationInMinutes = customDurationInMinutes,
+            IsActive = true
+        };
+    }
+
+    public void Update(decimal? customPrice, int? customDurationInMinutes)
+    {
+        if (customPrice.HasValue && customPrice <= 0)
+            throw new ArgumentException("CustomPrice must be greater than zero.", nameof(customPrice));
+        if (customDurationInMinutes.HasValue && customDurationInMinutes <= 0)
+            throw new ArgumentException("CustomDurationInMinutes must be greater than zero.", nameof(customDurationInMinutes));
+
+        CustomPrice = customPrice;
+        CustomDurationInMinutes = customDurationInMinutes;
+        Touch();
+    }
+
+    public void Activate() { IsActive = true; Touch(); }
+    public void Deactivate() { IsActive = false; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialty.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialty.cs
@@ -1,0 +1,34 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalSpecialty : TenantEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+
+    private ProfessionalSpecialty() { }
+
+    public static ProfessionalSpecialty Create(Guid tenantId, string name, string? description = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Specialty name is required.", nameof(name));
+
+        return new ProfessionalSpecialty
+        {
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description?.Trim()
+        };
+    }
+
+    public void Update(string name, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Specialty name is required.", nameof(name));
+
+        Name = name.Trim();
+        Description = description?.Trim();
+        Touch();
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialtyLink.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalSpecialtyLink.cs
@@ -1,0 +1,30 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class ProfessionalSpecialtyLink : TenantEntity
+{
+    public Guid ProfessionalId { get; private set; }
+    public Guid SpecialtyId { get; private set; }
+
+    // EF Core navigation — do not use in domain logic
+    public Professional? Professional { get; private set; }
+    public ProfessionalSpecialty? Specialty { get; private set; }
+
+    private ProfessionalSpecialtyLink() { }
+
+    public static ProfessionalSpecialtyLink Create(Guid tenantId, Guid professionalId, Guid specialtyId)
+    {
+        if (professionalId == Guid.Empty)
+            throw new ArgumentException("ProfessionalId is required.", nameof(professionalId));
+        if (specialtyId == Guid.Empty)
+            throw new ArgumentException("SpecialtyId is required.", nameof(specialtyId));
+
+        return new ProfessionalSpecialtyLink
+        {
+            TenantId = tenantId,
+            ProfessionalId = professionalId,
+            SpecialtyId = specialtyId
+        };
+    }
+}

--- a/2 - CRM/CRM.Domain/Entities/ProfessionalStatus.cs
+++ b/2 - CRM/CRM.Domain/Entities/ProfessionalStatus.cs
@@ -1,0 +1,10 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum ProfessionalStatus
+{
+    Draft = 0,
+    Active = 1,
+    Inactive = 2,
+    Suspended = 3,
+    Terminated = 4
+}

--- a/2 - CRM/CRM.Domain/Entities/RecurrenceFrequency.cs
+++ b/2 - CRM/CRM.Domain/Entities/RecurrenceFrequency.cs
@@ -1,0 +1,8 @@
+namespace MyCRM.CRM.Domain.Entities;
+
+public enum RecurrenceFrequency
+{
+    Weekly = 1,
+    Biweekly = 2,
+    Monthly = 3
+}

--- a/2 - CRM/CRM.Domain/Entities/Service.cs
+++ b/2 - CRM/CRM.Domain/Entities/Service.cs
@@ -1,0 +1,53 @@
+using MyCRM.Shared.Kernel.Entities;
+
+namespace MyCRM.CRM.Domain.Entities;
+
+public sealed class Service : TenantEntity
+{
+    public string Name { get; private set; } = string.Empty;
+    public string? Description { get; private set; }
+    public decimal DefaultPrice { get; private set; }
+    public int DefaultDurationInMinutes { get; private set; }
+    public bool IsActive { get; private set; }
+
+    private Service() { }
+
+    public static Service Create(Guid tenantId, string name, decimal defaultPrice, int defaultDurationInMinutes, string? description = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Service name is required.", nameof(name));
+        if (defaultPrice <= 0)
+            throw new ArgumentException("DefaultPrice must be greater than zero.", nameof(defaultPrice));
+        if (defaultDurationInMinutes <= 0)
+            throw new ArgumentException("DefaultDurationInMinutes must be greater than zero.", nameof(defaultDurationInMinutes));
+
+        return new Service
+        {
+            TenantId = tenantId,
+            Name = name.Trim(),
+            Description = description?.Trim(),
+            DefaultPrice = defaultPrice,
+            DefaultDurationInMinutes = defaultDurationInMinutes,
+            IsActive = true
+        };
+    }
+
+    public void Update(string name, decimal defaultPrice, int defaultDurationInMinutes, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Service name is required.", nameof(name));
+        if (defaultPrice <= 0)
+            throw new ArgumentException("DefaultPrice must be greater than zero.", nameof(defaultPrice));
+        if (defaultDurationInMinutes <= 0)
+            throw new ArgumentException("DefaultDurationInMinutes must be greater than zero.", nameof(defaultDurationInMinutes));
+
+        Name = name.Trim();
+        Description = description?.Trim();
+        DefaultPrice = defaultPrice;
+        DefaultDurationInMinutes = defaultDurationInMinutes;
+        Touch();
+    }
+
+    public void Activate() { IsActive = true; Touch(); }
+    public void Deactivate() { IsActive = false; Touch(); }
+}

--- a/2 - CRM/CRM.Domain/Repositories/IAppointmentRecurrenceRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IAppointmentRecurrenceRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IAppointmentRecurrenceRepository : IRepository<AppointmentRecurrence>
+{
+    Task<IReadOnlyList<AppointmentRecurrence>> GetActiveByParentAsync(Guid parentAppointmentId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IAppointmentRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IAppointmentRepository.cs
@@ -1,0 +1,11 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IAppointmentRepository : IRepository<Appointment>
+{
+    Task<bool> HasConflictAsync(Guid professionalId, DateTime startDateTime, DateTime endDateTime, Guid? excludeId = null, CancellationToken ct = default);
+    Task<IReadOnlyList<Appointment>> GetByProfessionalAsync(Guid tenantId, Guid professionalId, DateOnly date, CancellationToken ct = default);
+    Task<IReadOnlyList<Appointment>> GetByPatientAsync(Guid tenantId, Guid patientId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IAppointmentTaskRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IAppointmentTaskRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IAppointmentTaskRepository : IRepository<AppointmentTask>
+{
+    Task<IReadOnlyList<AppointmentTask>> GetPendingByAppointmentAsync(Guid appointmentId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/ICommissionRuleRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/ICommissionRuleRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface ICommissionRuleRepository : IRepository<CommissionRule>
+{
+    Task<CommissionRule?> GetEffectiveRuleAsync(Guid tenantId, Guid professionalId, Guid serviceId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IPatientRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IPatientRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IPatientRepository : IRepository<Patient>
+{
+    Task<bool> PersonAlreadyActivePatientAsync(Guid tenantId, Guid personId, Guid? excludeId = null, CancellationToken ct = default);
+    Task<Patient?> GetByPersonIdAsync(Guid tenantId, Guid personId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalRepository : IRepository<Professional>
+{
+    Task<bool> PersonAlreadyActiveProfessionalAsync(Guid tenantId, Guid personId, Guid? excludeId = null, CancellationToken ct = default);
+    Task<Professional?> GetByPersonIdAsync(Guid tenantId, Guid personId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalScheduleRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalScheduleRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalScheduleRepository : IRepository<ProfessionalSchedule>
+{
+    Task<bool> DayAlreadyScheduledAsync(Guid professionalId, int dayOfWeek, Guid? excludeId = null, CancellationToken ct = default);
+    Task<IReadOnlyList<ProfessionalSchedule>> GetByProfessionalAsync(Guid professionalId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalServiceRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalServiceRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalServiceRepository : IRepository<ProfessionalService>
+{
+    Task<bool> LinkExistsAsync(Guid professionalId, Guid serviceId, Guid? excludeId = null, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyLinkRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyLinkRepository.cs
@@ -1,0 +1,10 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalSpecialtyLinkRepository : IRepository<ProfessionalSpecialtyLink>
+{
+    Task<bool> LinkExistsAsync(Guid professionalId, Guid specialtyId, CancellationToken ct = default);
+    Task<int> CountByProfessionalAsync(Guid professionalId, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IProfessionalSpecialtyRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IProfessionalSpecialtyRepository : IRepository<ProfessionalSpecialty>
+{
+    Task<bool> NameExistsAsync(Guid tenantId, string name, Guid? excludeId = null, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Domain/Repositories/IServiceRepository.cs
+++ b/2 - CRM/CRM.Domain/Repositories/IServiceRepository.cs
@@ -1,0 +1,9 @@
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.Shared.Kernel.Repositories;
+
+namespace MyCRM.CRM.Domain.Repositories;
+
+public interface IServiceRepository : IRepository<Service>
+{
+    Task<bool> NameExistsAsync(Guid tenantId, string name, Guid? excludeId = null, CancellationToken ct = default);
+}

--- a/2 - CRM/CRM.Infrastructure/DependencyInjection.cs
+++ b/2 - CRM/CRM.Infrastructure/DependencyInjection.cs
@@ -33,6 +33,19 @@ public static class DependencyInjection
         services.AddScoped<IReconciliationRepository, ReconciliationRepository>();
         services.AddScoped<ICrmTenantProvisioningService, CrmTenantProvisioningService>();
 
+        // Agendamentos
+        services.AddScoped<IProfessionalSpecialtyRepository, ProfessionalSpecialtyRepository>();
+        services.AddScoped<IProfessionalSpecialtyLinkRepository, ProfessionalSpecialtyLinkRepository>();
+        services.AddScoped<IProfessionalRepository, ProfessionalRepository>();
+        services.AddScoped<IPatientRepository, PatientRepository>();
+        services.AddScoped<IServiceRepository, ServiceRepository>();
+        services.AddScoped<IProfessionalServiceRepository, ProfessionalServiceRepository>();
+        services.AddScoped<ICommissionRuleRepository, CommissionRuleRepository>();
+        services.AddScoped<IProfessionalScheduleRepository, ProfessionalScheduleRepository>();
+        services.AddScoped<IAppointmentRepository, AppointmentRepository>();
+        services.AddScoped<IAppointmentRecurrenceRepository, AppointmentRecurrenceRepository>();
+        services.AddScoped<IAppointmentTaskRepository, AppointmentTaskRepository>();
+
         return services;
     }
 }

--- a/2 - CRM/CRM.Infrastructure/Migrations/20260419191912_AddAgendamentosModule.Designer.cs
+++ b/2 - CRM/CRM.Infrastructure/Migrations/20260419191912_AddAgendamentosModule.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyCRM.CRM.Infrastructure.Persistence;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MyCRM.CRM.Infrastructure.Migrations
 {
     [DbContext(typeof(CRMDbContext))]
-    partial class CRMDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419191912_AddAgendamentosModule")]
+    partial class AddAgendamentosModule
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/2 - CRM/CRM.Infrastructure/Migrations/20260419191912_AddAgendamentosModule.cs
+++ b/2 - CRM/CRM.Infrastructure/Migrations/20260419191912_AddAgendamentosModule.cs
@@ -1,0 +1,745 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyCRM.CRM.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAgendamentosModule : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "WalletId",
+                schema: "crm",
+                table: "payment_methods",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "appointment_recurrences",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Frequency = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    EndDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    MaxOccurrences = table.Column<int>(type: "integer", nullable: true),
+                    ParentAppointmentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedOccurrences = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_appointment_recurrences", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "patients",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PersonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Notes = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_patients", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_patients_people_PersonId",
+                        column: x => x.PersonId,
+                        principalSchema: "crm",
+                        principalTable: "people",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "professional_specialties",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_professional_specialties", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "professionals",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    PersonId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CommissionPercentage = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: true),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Bio = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    LicenseNumber = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    WalletId = table.Column<Guid>(type: "uuid", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_professionals", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_professionals_people_PersonId",
+                        column: x => x.PersonId,
+                        principalSchema: "crm",
+                        principalTable: "people",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_professionals_wallets_WalletId",
+                        column: x => x.WalletId,
+                        principalSchema: "crm",
+                        principalTable: "wallets",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "services",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    DefaultPrice = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    DefaultDurationInMinutes = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_services", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "professional_schedules",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfessionalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DayOfWeek = table.Column<int>(type: "integer", nullable: false),
+                    StartTime = table.Column<TimeSpan>(type: "interval", nullable: false),
+                    EndTime = table.Column<TimeSpan>(type: "interval", nullable: false),
+                    IsAvailable = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_professional_schedules", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_professional_schedules_professionals_ProfessionalId",
+                        column: x => x.ProfessionalId,
+                        principalSchema: "crm",
+                        principalTable: "professionals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "professional_specialty_links",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfessionalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SpecialtyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_professional_specialty_links", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_professional_specialty_links_professional_specialties_Speci~",
+                        column: x => x.SpecialtyId,
+                        principalSchema: "crm",
+                        principalTable: "professional_specialties",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_professional_specialty_links_professionals_ProfessionalId",
+                        column: x => x.ProfessionalId,
+                        principalSchema: "crm",
+                        principalTable: "professionals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "appointments",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfessionalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PatientId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ServiceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StartDateTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EndDateTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Type = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Price = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: false),
+                    address_street = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    address_number = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    address_complement = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    address_neighborhood = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    address_city = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    address_state = table.Column<string>(type: "character varying(2)", maxLength: 2, nullable: true),
+                    address_zip_code = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: true),
+                    address_country = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: true),
+                    MeetingLink = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    PaymentReceiver = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    PaymentMethodId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    RecurrenceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ConfirmedBy = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    ConfirmedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CancellationReason = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    CancelledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CancelledWithLateNotice = table.Column<bool>(type: "boolean", nullable: false),
+                    NoShowAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CompletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RescheduledFrom = table.Column<Guid>(type: "uuid", nullable: true),
+                    RescheduledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    TransactionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Notes = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_appointments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_appointments_appointment_recurrences_RecurrenceId",
+                        column: x => x.RecurrenceId,
+                        principalSchema: "crm",
+                        principalTable: "appointment_recurrences",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_appointments_patients_PatientId",
+                        column: x => x.PatientId,
+                        principalSchema: "crm",
+                        principalTable: "patients",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_appointments_payment_methods_PaymentMethodId",
+                        column: x => x.PaymentMethodId,
+                        principalSchema: "crm",
+                        principalTable: "payment_methods",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_appointments_professionals_ProfessionalId",
+                        column: x => x.ProfessionalId,
+                        principalSchema: "crm",
+                        principalTable: "professionals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_appointments_services_ServiceId",
+                        column: x => x.ServiceId,
+                        principalSchema: "crm",
+                        principalTable: "services",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "commission_rules",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfessionalId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ServiceId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CompanyPercentage = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_commission_rules", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_commission_rules_professionals_ProfessionalId",
+                        column: x => x.ProfessionalId,
+                        principalSchema: "crm",
+                        principalTable: "professionals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_commission_rules_services_ServiceId",
+                        column: x => x.ServiceId,
+                        principalSchema: "crm",
+                        principalTable: "services",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "professional_services",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProfessionalId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ServiceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CustomPrice = table.Column<decimal>(type: "numeric(10,2)", precision: 10, scale: 2, nullable: true),
+                    CustomDurationInMinutes = table.Column<int>(type: "integer", nullable: true),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_professional_services", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_professional_services_professionals_ProfessionalId",
+                        column: x => x.ProfessionalId,
+                        principalSchema: "crm",
+                        principalTable: "professionals",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_professional_services_services_ServiceId",
+                        column: x => x.ServiceId,
+                        principalSchema: "crm",
+                        principalTable: "services",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "appointment_tasks",
+                schema: "crm",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    AppointmentId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Type = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    AssignedToUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    AssignedToRole = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Result = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    ResolvedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_appointment_tasks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_appointment_tasks_appointments_AppointmentId",
+                        column: x => x.AppointmentId,
+                        principalSchema: "crm",
+                        principalTable: "appointments",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_payment_methods_WalletId",
+                schema: "crm",
+                table: "payment_methods",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointment_recurrences_IsDeleted",
+                schema: "crm",
+                table: "appointment_recurrences",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointment_recurrences_ParentAppointmentId",
+                schema: "crm",
+                table: "appointment_recurrences",
+                column: "ParentAppointmentId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointment_tasks_AppointmentId_Status",
+                schema: "crm",
+                table: "appointment_tasks",
+                columns: new[] { "AppointmentId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointment_tasks_AssignedToUserId",
+                schema: "crm",
+                table: "appointment_tasks",
+                column: "AssignedToUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointment_tasks_IsDeleted",
+                schema: "crm",
+                table: "appointment_tasks",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_IsDeleted",
+                schema: "crm",
+                table: "appointments",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_PatientId",
+                schema: "crm",
+                table: "appointments",
+                column: "PatientId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_PaymentMethodId",
+                schema: "crm",
+                table: "appointments",
+                column: "PaymentMethodId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_ProfessionalId",
+                schema: "crm",
+                table: "appointments",
+                column: "ProfessionalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_RecurrenceId",
+                schema: "crm",
+                table: "appointments",
+                column: "RecurrenceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_ServiceId",
+                schema: "crm",
+                table: "appointments",
+                column: "ServiceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_Status",
+                schema: "crm",
+                table: "appointments",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_TenantId_PatientId",
+                schema: "crm",
+                table: "appointments",
+                columns: new[] { "TenantId", "PatientId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_appointments_TenantId_ProfessionalId_StartDateTime",
+                schema: "crm",
+                table: "appointments",
+                columns: new[] { "TenantId", "ProfessionalId", "StartDateTime" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_commission_rules_IsDeleted",
+                schema: "crm",
+                table: "commission_rules",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_commission_rules_ProfessionalId",
+                schema: "crm",
+                table: "commission_rules",
+                column: "ProfessionalId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_commission_rules_ServiceId",
+                schema: "crm",
+                table: "commission_rules",
+                column: "ServiceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_commission_rules_TenantId_ProfessionalId_ServiceId",
+                schema: "crm",
+                table: "commission_rules",
+                columns: new[] { "TenantId", "ProfessionalId", "ServiceId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_patients_IsDeleted",
+                schema: "crm",
+                table: "patients",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_patients_PersonId",
+                schema: "crm",
+                table: "patients",
+                column: "PersonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_patients_Status",
+                schema: "crm",
+                table: "patients",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_patients_TenantId_PersonId",
+                schema: "crm",
+                table: "patients",
+                columns: new[] { "TenantId", "PersonId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_schedules_IsDeleted",
+                schema: "crm",
+                table: "professional_schedules",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_schedules_ProfessionalId_DayOfWeek",
+                schema: "crm",
+                table: "professional_schedules",
+                columns: new[] { "ProfessionalId", "DayOfWeek" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_services_IsDeleted",
+                schema: "crm",
+                table: "professional_services",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_services_ProfessionalId_ServiceId",
+                schema: "crm",
+                table: "professional_services",
+                columns: new[] { "ProfessionalId", "ServiceId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_services_ServiceId",
+                schema: "crm",
+                table: "professional_services",
+                column: "ServiceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_specialties_IsDeleted",
+                schema: "crm",
+                table: "professional_specialties",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_specialties_TenantId_Name",
+                schema: "crm",
+                table: "professional_specialties",
+                columns: new[] { "TenantId", "Name" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_specialty_links_ProfessionalId_SpecialtyId",
+                schema: "crm",
+                table: "professional_specialty_links",
+                columns: new[] { "ProfessionalId", "SpecialtyId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professional_specialty_links_SpecialtyId",
+                schema: "crm",
+                table: "professional_specialty_links",
+                column: "SpecialtyId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professionals_IsDeleted",
+                schema: "crm",
+                table: "professionals",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professionals_PersonId",
+                schema: "crm",
+                table: "professionals",
+                column: "PersonId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professionals_Status",
+                schema: "crm",
+                table: "professionals",
+                column: "Status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professionals_TenantId_PersonId",
+                schema: "crm",
+                table: "professionals",
+                columns: new[] { "TenantId", "PersonId" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_professionals_WalletId",
+                schema: "crm",
+                table: "professionals",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_services_IsActive",
+                schema: "crm",
+                table: "services",
+                column: "IsActive");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_services_IsDeleted",
+                schema: "crm",
+                table: "services",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_services_TenantId_Name",
+                schema: "crm",
+                table: "services",
+                columns: new[] { "TenantId", "Name" },
+                unique: true,
+                filter: "\"IsDeleted\" = false");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_payment_methods_wallets_WalletId",
+                schema: "crm",
+                table: "payment_methods",
+                column: "WalletId",
+                principalSchema: "crm",
+                principalTable: "wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_payment_methods_wallets_WalletId",
+                schema: "crm",
+                table: "payment_methods");
+
+            migrationBuilder.DropTable(
+                name: "appointment_tasks",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "commission_rules",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "professional_schedules",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "professional_services",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "professional_specialty_links",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "appointments",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "professional_specialties",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "appointment_recurrences",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "patients",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "professionals",
+                schema: "crm");
+
+            migrationBuilder.DropTable(
+                name: "services",
+                schema: "crm");
+
+            migrationBuilder.DropIndex(
+                name: "IX_payment_methods_WalletId",
+                schema: "crm",
+                table: "payment_methods");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                schema: "crm",
+                table: "payment_methods");
+        }
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/CRMDbContext.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/CRMDbContext.cs
@@ -32,6 +32,19 @@ public sealed class CRMDbContext : DbContext
     public DbSet<Transaction>     Transactions     => Set<Transaction>();
     public DbSet<Reconciliation>  Reconciliations  => Set<Reconciliation>();
 
+    // Agendamentos
+    public DbSet<ProfessionalSpecialty>     ProfessionalSpecialties     => Set<ProfessionalSpecialty>();
+    public DbSet<ProfessionalSpecialtyLink> ProfessionalSpecialtyLinks  => Set<ProfessionalSpecialtyLink>();
+    public DbSet<Professional>              Professionals               => Set<Professional>();
+    public DbSet<Patient>                   Patients                    => Set<Patient>();
+    public DbSet<Service>                   Services                    => Set<Service>();
+    public DbSet<ProfessionalService>       ProfessionalServices        => Set<ProfessionalService>();
+    public DbSet<CommissionRule>            CommissionRules             => Set<CommissionRule>();
+    public DbSet<ProfessionalSchedule>      ProfessionalSchedules       => Set<ProfessionalSchedule>();
+    public DbSet<Appointment>               Appointments                => Set<Appointment>();
+    public DbSet<AppointmentRecurrence>     AppointmentRecurrences      => Set<AppointmentRecurrence>();
+    public DbSet<AppointmentTask>           AppointmentTasks            => Set<AppointmentTask>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema("crm");
@@ -74,6 +87,39 @@ public sealed class CRMDbContext : DbContext
             .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
 
         modelBuilder.Entity<Reconciliation>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<ProfessionalSpecialty>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<ProfessionalSpecialtyLink>()
+            .HasQueryFilter(x => x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<Professional>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<Patient>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<Service>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<ProfessionalService>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<CommissionRule>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<ProfessionalSchedule>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<Appointment>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<AppointmentRecurrence>()
+            .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
+
+        modelBuilder.Entity<AppointmentTask>()
             .HasQueryFilter(x => !x.IsDeleted && x.TenantId == _tenant.TenantId);
 
         base.OnModelCreating(modelBuilder);

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/AppointmentConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/AppointmentConfiguration.cs
@@ -1,0 +1,78 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class AppointmentConfiguration : IEntityTypeConfiguration<Appointment>
+{
+    public void Configure(EntityTypeBuilder<Appointment> builder)
+    {
+        builder.ToTable("appointments");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.ProfessionalId).IsRequired();
+        builder.Property(x => x.PatientId).IsRequired();
+        builder.Property(x => x.ServiceId).IsRequired();
+        builder.Property(x => x.StartDateTime).IsRequired();
+        builder.Property(x => x.EndDateTime).IsRequired();
+        builder.Property(x => x.Type).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+        builder.Property(x => x.Price).IsRequired().HasPrecision(10, 2);
+        builder.Property(x => x.PaymentReceiver).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+        builder.Property(x => x.PaymentMethodId).IsRequired();
+        builder.Property(x => x.Status).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+        builder.Property(x => x.MeetingLink).HasMaxLength(500);
+        builder.Property(x => x.ConfirmedBy).HasMaxLength(100);
+        builder.Property(x => x.CancellationReason).HasMaxLength(1000);
+        builder.Property(x => x.Notes).HasMaxLength(2000);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        // Address as owned type (embedded columns)
+        builder.OwnsOne(x => x.Address, a =>
+        {
+            a.Property(x => x.Street).HasMaxLength(300).HasColumnName("address_street");
+            a.Property(x => x.Number).HasMaxLength(20).HasColumnName("address_number");
+            a.Property(x => x.Complement).HasMaxLength(100).HasColumnName("address_complement");
+            a.Property(x => x.Neighborhood).HasMaxLength(200).HasColumnName("address_neighborhood");
+            a.Property(x => x.City).HasMaxLength(200).HasColumnName("address_city");
+            a.Property(x => x.State).HasMaxLength(2).HasColumnName("address_state");
+            a.Property(x => x.ZipCode).HasMaxLength(20).HasColumnName("address_zip_code");
+            a.Property(x => x.Country).HasMaxLength(10).HasColumnName("address_country");
+        });
+
+        builder.HasOne(x => x.Professional)
+            .WithMany()
+            .HasForeignKey(x => x.ProfessionalId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(x => x.Patient)
+            .WithMany()
+            .HasForeignKey(x => x.PatientId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(x => x.Service)
+            .WithMany()
+            .HasForeignKey(x => x.ServiceId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(x => x.PaymentMethod)
+            .WithMany()
+            .HasForeignKey(x => x.PaymentMethodId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(x => x.Recurrence)
+            .WithMany()
+            .HasForeignKey(x => x.RecurrenceId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasIndex(x => new { x.TenantId, x.ProfessionalId, x.StartDateTime });
+        builder.HasIndex(x => new { x.TenantId, x.PatientId });
+        builder.HasIndex(x => x.Status);
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/AppointmentRecurrenceConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/AppointmentRecurrenceConfiguration.cs
@@ -1,0 +1,25 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class AppointmentRecurrenceConfiguration : IEntityTypeConfiguration<AppointmentRecurrence>
+{
+    public void Configure(EntityTypeBuilder<AppointmentRecurrence> builder)
+    {
+        builder.ToTable("appointment_recurrences");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.Frequency).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+        builder.Property(x => x.ParentAppointmentId).IsRequired();
+        builder.Property(x => x.CreatedOccurrences).IsRequired().HasDefaultValue(0);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasIndex(x => x.ParentAppointmentId);
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/AppointmentTaskConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/AppointmentTaskConfiguration.cs
@@ -1,0 +1,34 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class AppointmentTaskConfiguration : IEntityTypeConfiguration<AppointmentTask>
+{
+    public void Configure(EntityTypeBuilder<AppointmentTask> builder)
+    {
+        builder.ToTable("appointment_tasks");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.AppointmentId).IsRequired();
+        builder.Property(x => x.Type).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+        builder.Property(x => x.Status).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+        builder.Property(x => x.AssignedToRole).HasMaxLength(100);
+        builder.Property(x => x.Result).HasMaxLength(200);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasOne(x => x.Appointment)
+            .WithMany()
+            .HasForeignKey(x => x.AppointmentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => new { x.AppointmentId, x.Status });
+        builder.HasIndex(x => x.AssignedToUserId);
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/CommissionRuleConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/CommissionRuleConfiguration.cs
@@ -1,0 +1,36 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class CommissionRuleConfiguration : IEntityTypeConfiguration<CommissionRule>
+{
+    public void Configure(EntityTypeBuilder<CommissionRule> builder)
+    {
+        builder.ToTable("commission_rules");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.CompanyPercentage).IsRequired().HasPrecision(5, 2);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasOne(x => x.Professional)
+            .WithMany()
+            .HasForeignKey(x => x.ProfessionalId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Service)
+            .WithMany()
+            .HasForeignKey(x => x.ServiceId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        // Tenant-level rule (both FKs null): max 1 per tenant
+        builder.HasIndex(x => new { x.TenantId, x.ProfessionalId, x.ServiceId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/PatientConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/PatientConfiguration.cs
@@ -1,0 +1,37 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class PatientConfiguration : IEntityTypeConfiguration<Patient>
+{
+    public void Configure(EntityTypeBuilder<Patient> builder)
+    {
+        builder.ToTable("patients");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+
+        builder.Property(x => x.PersonId).IsRequired();
+        builder.HasOne(x => x.Person)
+            .WithMany()
+            .HasForeignKey(x => x.PersonId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Property(x => x.Status).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+
+        builder.Property(x => x.Notes).HasMaxLength(2000);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        // Only one active Patient per Person per tenant (RN-043)
+        builder.HasIndex(x => new { x.TenantId, x.PersonId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.Status);
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalConfiguration.cs
@@ -1,0 +1,45 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class ProfessionalConfiguration : IEntityTypeConfiguration<Professional>
+{
+    public void Configure(EntityTypeBuilder<Professional> builder)
+    {
+        builder.ToTable("professionals");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+
+        builder.Property(x => x.PersonId).IsRequired();
+        builder.HasOne(x => x.Person)
+            .WithMany()
+            .HasForeignKey(x => x.PersonId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Property(x => x.Status).IsRequired()
+            .HasConversion<string>().HasMaxLength(50);
+
+        builder.Property(x => x.Bio).HasMaxLength(2000);
+        builder.Property(x => x.LicenseNumber).HasMaxLength(100);
+        builder.Property(x => x.CommissionPercentage).HasPrecision(5, 2);
+
+        builder.HasOne(x => x.Wallet)
+            .WithMany()
+            .HasForeignKey(x => x.WalletId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        // Only one active Professional per Person per tenant (RN-042)
+        builder.HasIndex(x => new { x.TenantId, x.PersonId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.Status);
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalScheduleConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalScheduleConfiguration.cs
@@ -1,0 +1,34 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class ProfessionalScheduleConfiguration : IEntityTypeConfiguration<ProfessionalSchedule>
+{
+    public void Configure(EntityTypeBuilder<ProfessionalSchedule> builder)
+    {
+        builder.ToTable("professional_schedules");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.ProfessionalId).IsRequired();
+        builder.Property(x => x.DayOfWeek).IsRequired();
+        builder.Property(x => x.StartTime).IsRequired();
+        builder.Property(x => x.EndTime).IsRequired();
+        builder.Property(x => x.IsAvailable).IsRequired().HasDefaultValue(true);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasOne(x => x.Professional)
+            .WithMany()
+            .HasForeignKey(x => x.ProfessionalId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasIndex(x => new { x.ProfessionalId, x.DayOfWeek })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalServiceConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalServiceConfiguration.cs
@@ -1,0 +1,38 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class ProfessionalServiceConfiguration : IEntityTypeConfiguration<ProfessionalService>
+{
+    public void Configure(EntityTypeBuilder<ProfessionalService> builder)
+    {
+        builder.ToTable("professional_services");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.ProfessionalId).IsRequired();
+        builder.Property(x => x.ServiceId).IsRequired();
+        builder.Property(x => x.CustomPrice).HasPrecision(10, 2);
+        builder.Property(x => x.IsActive).IsRequired().HasDefaultValue(true);
+        builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(x => x.CreatedAt).IsRequired();
+
+        builder.HasOne(x => x.Professional)
+            .WithMany()
+            .HasForeignKey(x => x.ProfessionalId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Service)
+            .WithMany()
+            .HasForeignKey(x => x.ServiceId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.ProfessionalId, x.ServiceId })
+            .IsUnique()
+            .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.IsDeleted);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalSpecialtyConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalSpecialtyConfiguration.cs
@@ -1,27 +1,26 @@
+using MyCRM.CRM.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MyCRM.CRM.Domain.Entities;
 
 namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
 
-public sealed class PaymentMethodConfiguration : IEntityTypeConfiguration<PaymentMethod>
+public sealed class ProfessionalSpecialtyConfiguration : IEntityTypeConfiguration<ProfessionalSpecialty>
 {
-    public void Configure(EntityTypeBuilder<PaymentMethod> builder)
+    public void Configure(EntityTypeBuilder<ProfessionalSpecialty> builder)
     {
-        builder.ToTable("payment_methods");
+        builder.ToTable("professional_specialties");
         builder.HasKey(x => x.Id);
         builder.Property(x => x.Id).ValueGeneratedNever();
         builder.Property(x => x.TenantId).IsRequired();
         builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Description).HasMaxLength(1000);
         builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
         builder.Property(x => x.CreatedAt).IsRequired();
 
-        builder.HasOne(x => x.Wallet)
-            .WithMany()
-            .HasForeignKey(x => x.WalletId)
-            .OnDelete(DeleteBehavior.SetNull);
-
         builder.HasIndex(x => new { x.TenantId, x.Name })
+            .IsUnique()
             .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.IsDeleted);
     }
 }

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalSpecialtyLinkConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ProfessionalSpecialtyLinkConfiguration.cs
@@ -1,0 +1,30 @@
+using MyCRM.CRM.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
+
+public sealed class ProfessionalSpecialtyLinkConfiguration : IEntityTypeConfiguration<ProfessionalSpecialtyLink>
+{
+    public void Configure(EntityTypeBuilder<ProfessionalSpecialtyLink> builder)
+    {
+        builder.ToTable("professional_specialty_links");
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.Id).ValueGeneratedNever();
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.ProfessionalId).IsRequired();
+        builder.Property(x => x.SpecialtyId).IsRequired();
+
+        builder.HasOne(x => x.Professional)
+            .WithMany()
+            .HasForeignKey(x => x.ProfessionalId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Specialty)
+            .WithMany()
+            .HasForeignKey(x => x.SpecialtyId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(x => new { x.ProfessionalId, x.SpecialtyId }).IsUnique();
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
+++ b/2 - CRM/CRM.Infrastructure/Persistence/Configurations/ServiceConfiguration.cs
@@ -1,27 +1,30 @@
+using MyCRM.CRM.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using MyCRM.CRM.Domain.Entities;
 
 namespace MyCRM.CRM.Infrastructure.Persistence.Configurations;
 
-public sealed class PaymentMethodConfiguration : IEntityTypeConfiguration<PaymentMethod>
+public sealed class ServiceConfiguration : IEntityTypeConfiguration<Service>
 {
-    public void Configure(EntityTypeBuilder<PaymentMethod> builder)
+    public void Configure(EntityTypeBuilder<Service> builder)
     {
-        builder.ToTable("payment_methods");
+        builder.ToTable("services");
         builder.HasKey(x => x.Id);
         builder.Property(x => x.Id).ValueGeneratedNever();
         builder.Property(x => x.TenantId).IsRequired();
         builder.Property(x => x.Name).IsRequired().HasMaxLength(200);
+        builder.Property(x => x.Description).HasMaxLength(1000);
+        builder.Property(x => x.DefaultPrice).IsRequired().HasPrecision(10, 2);
+        builder.Property(x => x.DefaultDurationInMinutes).IsRequired();
+        builder.Property(x => x.IsActive).IsRequired().HasDefaultValue(true);
         builder.Property(x => x.IsDeleted).IsRequired().HasDefaultValue(false);
         builder.Property(x => x.CreatedAt).IsRequired();
 
-        builder.HasOne(x => x.Wallet)
-            .WithMany()
-            .HasForeignKey(x => x.WalletId)
-            .OnDelete(DeleteBehavior.SetNull);
-
         builder.HasIndex(x => new { x.TenantId, x.Name })
+            .IsUnique()
             .HasFilter("\"IsDeleted\" = false");
+
+        builder.HasIndex(x => x.IsActive);
+        builder.HasIndex(x => x.IsDeleted);
     }
 }

--- a/2 - CRM/CRM.Infrastructure/Repositories/AppointmentRecurrenceRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/AppointmentRecurrenceRepository.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class AppointmentRecurrenceRepository : IAppointmentRecurrenceRepository
+{
+    private readonly CRMDbContext _db;
+    public AppointmentRecurrenceRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<AppointmentRecurrence> Query() => _db.AppointmentRecurrences.AsNoTracking();
+    public async Task<IReadOnlyList<AppointmentRecurrence>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.AppointmentRecurrences.AsNoTracking().ToListAsync(ct);
+    public async Task<AppointmentRecurrence?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.AppointmentRecurrences.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(AppointmentRecurrence entity, CancellationToken ct = default) =>
+        await _db.AppointmentRecurrences.AddAsync(entity, ct);
+    public void Update(AppointmentRecurrence entity) => _db.AppointmentRecurrences.Update(entity);
+    public void Delete(AppointmentRecurrence entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<IReadOnlyList<AppointmentRecurrence>> GetActiveByParentAsync(Guid parentAppointmentId, CancellationToken ct = default) =>
+        await _db.AppointmentRecurrences.AsNoTracking()
+            .Where(x => x.ParentAppointmentId == parentAppointmentId)
+            .ToListAsync(ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/AppointmentRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/AppointmentRepository.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class AppointmentRepository : IAppointmentRepository
+{
+    private readonly CRMDbContext _db;
+    public AppointmentRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<Appointment> Query() => _db.Appointments.AsNoTracking();
+    public async Task<IReadOnlyList<Appointment>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.Appointments.AsNoTracking().ToListAsync(ct);
+    public async Task<Appointment?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.Appointments.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(Appointment entity, CancellationToken ct = default) =>
+        await _db.Appointments.AddAsync(entity, ct);
+    public void Update(Appointment entity) => _db.Appointments.Update(entity);
+    public void Delete(Appointment entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> HasConflictAsync(Guid professionalId, DateTime startDateTime, DateTime endDateTime, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.Appointments.AnyAsync(
+            x => x.ProfessionalId == professionalId
+              && (excludeId == null || x.Id != excludeId)
+              && x.StartDateTime < endDateTime
+              && x.EndDateTime > startDateTime, ct);
+
+    public async Task<IReadOnlyList<Appointment>> GetByProfessionalAsync(Guid tenantId, Guid professionalId, DateOnly date, CancellationToken ct = default)
+    {
+        var start = date.ToDateTime(TimeOnly.MinValue);
+        var end = date.ToDateTime(TimeOnly.MaxValue);
+        return await _db.Appointments.AsNoTracking()
+            .Where(x => x.TenantId == tenantId && x.ProfessionalId == professionalId
+                     && x.StartDateTime >= start && x.StartDateTime <= end)
+            .OrderBy(x => x.StartDateTime)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<Appointment>> GetByPatientAsync(Guid tenantId, Guid patientId, CancellationToken ct = default) =>
+        await _db.Appointments.AsNoTracking()
+            .Where(x => x.TenantId == tenantId && x.PatientId == patientId)
+            .OrderByDescending(x => x.StartDateTime)
+            .ToListAsync(ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/AppointmentTaskRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/AppointmentTaskRepository.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class AppointmentTaskRepository : IAppointmentTaskRepository
+{
+    private readonly CRMDbContext _db;
+    public AppointmentTaskRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<AppointmentTask> Query() => _db.AppointmentTasks.AsNoTracking();
+    public async Task<IReadOnlyList<AppointmentTask>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.AppointmentTasks.AsNoTracking().ToListAsync(ct);
+    public async Task<AppointmentTask?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.AppointmentTasks.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(AppointmentTask entity, CancellationToken ct = default) =>
+        await _db.AppointmentTasks.AddAsync(entity, ct);
+    public void Update(AppointmentTask entity) => _db.AppointmentTasks.Update(entity);
+    public void Delete(AppointmentTask entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<IReadOnlyList<AppointmentTask>> GetPendingByAppointmentAsync(Guid appointmentId, CancellationToken ct = default) =>
+        await _db.AppointmentTasks.AsNoTracking()
+            .Where(x => x.AppointmentId == appointmentId && x.Status == AppointmentTaskStatus.Pending)
+            .ToListAsync(ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/CommissionRuleRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/CommissionRuleRepository.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class CommissionRuleRepository : ICommissionRuleRepository
+{
+    private readonly CRMDbContext _db;
+    public CommissionRuleRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<CommissionRule> Query() => _db.CommissionRules.AsNoTracking();
+    public async Task<IReadOnlyList<CommissionRule>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.CommissionRules.AsNoTracking().ToListAsync(ct);
+    public async Task<CommissionRule?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.CommissionRules.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(CommissionRule entity, CancellationToken ct = default) =>
+        await _db.CommissionRules.AddAsync(entity, ct);
+    public void Update(CommissionRule entity) => _db.CommissionRules.Update(entity);
+    public void Delete(CommissionRule entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<CommissionRule?> GetEffectiveRuleAsync(Guid tenantId, Guid professionalId, Guid serviceId, CancellationToken ct = default)
+    {
+        // Priority: professional+service > professional > tenant
+        return await _db.CommissionRules
+            .Where(x => x.TenantId == tenantId)
+            .OrderByDescending(x => x.ProfessionalId != null && x.ServiceId != null)
+            .ThenByDescending(x => x.ProfessionalId != null)
+            .FirstOrDefaultAsync(
+                x => (x.ProfessionalId == professionalId && x.ServiceId == serviceId)
+                  || (x.ProfessionalId == professionalId && x.ServiceId == null)
+                  || (x.ProfessionalId == null && x.ServiceId == null), ct);
+    }
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/PatientRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/PatientRepository.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class PatientRepository : IPatientRepository
+{
+    private readonly CRMDbContext _db;
+    public PatientRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<Patient> Query() => _db.Patients.AsNoTracking();
+    public async Task<IReadOnlyList<Patient>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.Patients.AsNoTracking().ToListAsync(ct);
+    public async Task<Patient?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.Patients.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(Patient entity, CancellationToken ct = default) =>
+        await _db.Patients.AddAsync(entity, ct);
+    public void Update(Patient entity) => _db.Patients.Update(entity);
+    public void Delete(Patient entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> PersonAlreadyActivePatientAsync(Guid tenantId, Guid personId, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.Patients.AnyAsync(
+            x => x.TenantId == tenantId && x.PersonId == personId && (excludeId == null || x.Id != excludeId), ct);
+
+    public async Task<Patient?> GetByPersonIdAsync(Guid tenantId, Guid personId, CancellationToken ct = default) =>
+        await _db.Patients.FirstOrDefaultAsync(x => x.TenantId == tenantId && x.PersonId == personId, ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalRepository.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class ProfessionalRepository : IProfessionalRepository
+{
+    private readonly CRMDbContext _db;
+    public ProfessionalRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<Professional> Query() => _db.Professionals.AsNoTracking();
+    public async Task<IReadOnlyList<Professional>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.Professionals.AsNoTracking().ToListAsync(ct);
+    public async Task<Professional?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.Professionals.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(Professional entity, CancellationToken ct = default) =>
+        await _db.Professionals.AddAsync(entity, ct);
+    public void Update(Professional entity) => _db.Professionals.Update(entity);
+    public void Delete(Professional entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> PersonAlreadyActiveProfessionalAsync(Guid tenantId, Guid personId, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.Professionals.AnyAsync(
+            x => x.TenantId == tenantId && x.PersonId == personId && (excludeId == null || x.Id != excludeId), ct);
+
+    public async Task<Professional?> GetByPersonIdAsync(Guid tenantId, Guid personId, CancellationToken ct = default) =>
+        await _db.Professionals.FirstOrDefaultAsync(x => x.TenantId == tenantId && x.PersonId == personId, ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalScheduleRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalScheduleRepository.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class ProfessionalScheduleRepository : IProfessionalScheduleRepository
+{
+    private readonly CRMDbContext _db;
+    public ProfessionalScheduleRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<ProfessionalSchedule> Query() => _db.ProfessionalSchedules.AsNoTracking();
+    public async Task<IReadOnlyList<ProfessionalSchedule>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.ProfessionalSchedules.AsNoTracking().ToListAsync(ct);
+    public async Task<ProfessionalSchedule?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.ProfessionalSchedules.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(ProfessionalSchedule entity, CancellationToken ct = default) =>
+        await _db.ProfessionalSchedules.AddAsync(entity, ct);
+    public void Update(ProfessionalSchedule entity) => _db.ProfessionalSchedules.Update(entity);
+    public void Delete(ProfessionalSchedule entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> DayAlreadyScheduledAsync(Guid professionalId, int dayOfWeek, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.ProfessionalSchedules.AnyAsync(
+            x => x.ProfessionalId == professionalId && x.DayOfWeek == dayOfWeek && (excludeId == null || x.Id != excludeId), ct);
+
+    public async Task<IReadOnlyList<ProfessionalSchedule>> GetByProfessionalAsync(Guid professionalId, CancellationToken ct = default) =>
+        await _db.ProfessionalSchedules.AsNoTracking()
+            .Where(x => x.ProfessionalId == professionalId)
+            .OrderBy(x => x.DayOfWeek)
+            .ToListAsync(ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalServiceRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalServiceRepository.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class ProfessionalServiceRepository : IProfessionalServiceRepository
+{
+    private readonly CRMDbContext _db;
+    public ProfessionalServiceRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<ProfessionalService> Query() => _db.ProfessionalServices.AsNoTracking();
+    public async Task<IReadOnlyList<ProfessionalService>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.ProfessionalServices.AsNoTracking().ToListAsync(ct);
+    public async Task<ProfessionalService?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.ProfessionalServices.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(ProfessionalService entity, CancellationToken ct = default) =>
+        await _db.ProfessionalServices.AddAsync(entity, ct);
+    public void Update(ProfessionalService entity) => _db.ProfessionalServices.Update(entity);
+    public void Delete(ProfessionalService entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> LinkExistsAsync(Guid professionalId, Guid serviceId, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.ProfessionalServices.AnyAsync(
+            x => x.ProfessionalId == professionalId && x.ServiceId == serviceId && (excludeId == null || x.Id != excludeId), ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalSpecialtyLinkRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalSpecialtyLinkRepository.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class ProfessionalSpecialtyLinkRepository : IProfessionalSpecialtyLinkRepository
+{
+    private readonly CRMDbContext _db;
+    public ProfessionalSpecialtyLinkRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<ProfessionalSpecialtyLink> Query() => _db.ProfessionalSpecialtyLinks.AsNoTracking();
+    public async Task<IReadOnlyList<ProfessionalSpecialtyLink>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialtyLinks.AsNoTracking().ToListAsync(ct);
+    public async Task<ProfessionalSpecialtyLink?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialtyLinks.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(ProfessionalSpecialtyLink entity, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialtyLinks.AddAsync(entity, ct);
+    public void Update(ProfessionalSpecialtyLink entity) => _db.ProfessionalSpecialtyLinks.Update(entity);
+    public void Delete(ProfessionalSpecialtyLink entity) => _db.ProfessionalSpecialtyLinks.Remove(entity);
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> LinkExistsAsync(Guid professionalId, Guid specialtyId, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialtyLinks.AnyAsync(
+            x => x.ProfessionalId == professionalId && x.SpecialtyId == specialtyId, ct);
+
+    public async Task<int> CountByProfessionalAsync(Guid professionalId, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialtyLinks.CountAsync(x => x.ProfessionalId == professionalId, ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalSpecialtyRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/ProfessionalSpecialtyRepository.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class ProfessionalSpecialtyRepository : IProfessionalSpecialtyRepository
+{
+    private readonly CRMDbContext _db;
+    public ProfessionalSpecialtyRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<ProfessionalSpecialty> Query() => _db.ProfessionalSpecialties.AsNoTracking();
+    public async Task<IReadOnlyList<ProfessionalSpecialty>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialties.AsNoTracking().ToListAsync(ct);
+    public async Task<ProfessionalSpecialty?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialties.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(ProfessionalSpecialty entity, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialties.AddAsync(entity, ct);
+    public void Update(ProfessionalSpecialty entity) => _db.ProfessionalSpecialties.Update(entity);
+    public void Delete(ProfessionalSpecialty entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> NameExistsAsync(Guid tenantId, string name, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.ProfessionalSpecialties.AnyAsync(
+            x => x.TenantId == tenantId && x.Name == name && (excludeId == null || x.Id != excludeId), ct);
+}

--- a/2 - CRM/CRM.Infrastructure/Repositories/ServiceRepository.cs
+++ b/2 - CRM/CRM.Infrastructure/Repositories/ServiceRepository.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using MyCRM.CRM.Domain.Entities;
+using MyCRM.CRM.Domain.Repositories;
+using MyCRM.CRM.Infrastructure.Persistence;
+
+namespace MyCRM.CRM.Infrastructure.Repositories;
+
+public sealed class ServiceRepository : IServiceRepository
+{
+    private readonly CRMDbContext _db;
+    public ServiceRepository(CRMDbContext db) => _db = db;
+
+    public IQueryable<Service> Query() => _db.Services.AsNoTracking();
+    public async Task<IReadOnlyList<Service>> GetAllAsync(CancellationToken ct = default) =>
+        await _db.Services.AsNoTracking().ToListAsync(ct);
+    public async Task<Service?> GetByIdAsync(Guid id, CancellationToken ct = default) =>
+        await _db.Services.FirstOrDefaultAsync(x => x.Id == id, ct);
+    public async Task AddAsync(Service entity, CancellationToken ct = default) =>
+        await _db.Services.AddAsync(entity, ct);
+    public void Update(Service entity) => _db.Services.Update(entity);
+    public void Delete(Service entity) => entity.SoftDelete();
+    public Task<int> SaveChangesAsync(CancellationToken ct = default) => _db.SaveChangesAsync(ct);
+
+    public async Task<bool> NameExistsAsync(Guid tenantId, string name, Guid? excludeId = null, CancellationToken ct = default) =>
+        await _db.Services.AnyAsync(
+            x => x.TenantId == tenantId && x.Name == name && (excludeId == null || x.Id != excludeId), ct);
+}


### PR DESCRIPTION
## Summary
- 11 EF Core configurations criadas com índices, constraints UNIQUE e conversões de enum
- `Address` mapeada como owned type em `AppointmentConfiguration`
- `PaymentMethodConfiguration` atualizado com FK para `Wallet`
- 11 repositórios concretos implementados com queries específicas por domínio
- `CRMDbContext` atualizado: 11 novos DbSets + query filters (IsDeleted + TenantId)
- DI registrado em `DependencyInjection.cs`
- Migration `AddAgendamentosModule` gerada

## Test plan
- [ ] `dotnet build MyCRM.sln` — zero erros ✅
- [ ] `dotnet ef migrations add` — gerado sem erros ✅
- [ ] Sem testes unitários neste lote (apenas infra, conforme spec)

**Depende de:** #91 (Lote 1 — Domain entities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)